### PR TITLE
require iohgatp alignment

### DIFF
--- a/iommu_data_structures.adoc
+++ b/iommu_data_structures.adoc
@@ -392,10 +392,7 @@ Implementations are not required to support all defined mode settings for
 in the harts integrated into the system or a subset thereof.
 
 The root page table as determined by `iohgatp.PPN` is 16 KiB and must be aligned
-to a 16-KiB boundary.  If the root page table is not aligned to 16 KiB as 
-required, then all entries in that G-stage root page table appear to an IOMMU as
-`UNSPECIFIED` and any address an IOMMU may compute and use for accessing an
-entry in the root page table is also `UNSPECIFIED`.
+to a 16-KiB boundary.
 
 .IO hypervisor guest address translation and protection (`iohgatp`) field
 [wavedrom, , ]
@@ -1201,6 +1198,8 @@ is as follows:
 .. `capabilities.Sv57x4` is 0 and `DC.iohgatp.MODE` is `Sv57x4`
 .. `capabilities.MSI_FLAT` is 1 and `DC.msiptp.MODE` is not `Bare` 
    and not `Flat`
+.. `DC.iohgatp.MODE` is not `Bare` and the root page table determined by
+   `DC.iohgatp.PPN` is not aligned to a 16-KiB boundary.
 . The device-context has been successfully located and may be cached.
 
 [NOTE]


### PR DESCRIPTION
Root page table determined by IOHGATP in DC must be 16 KiB aligned.