### PR TITLE
Documentation updates to IOMMU registers chapter

### DIFF
--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -332,12 +332,12 @@ are enabled (i.e. `cqcsr.cqon/cqen == 1`, `fqcsr.fqon/cqen == 1`, or
                                 may ignore the second write and others may 
                                 perform the actions determined by the second 
                                 write. Software must verify that the `busy` 
-                                bit is 0 before writing to the `ddtp`.
-
+                                bit is 0 before writing to the `ddtp`. +
+                                                                               +
                                 If the `busy` bit reads 0 then the IOMMU has 
                                 completed the operations associated with the 
-                                previous write to `ddtp`.
-
+                                previous write to `ddtp`. +
+                                                                               +
                                 An IOMMU that can complete these operations 
                                 synchronously may hard-wire this bit to 0.
 |9:5   |`reserved` |WPRI      | Reserved for standard use
@@ -370,9 +370,9 @@ To change DDT levels, the IOMMU must first be transitioned to `Bare` or `Off`
 state.
 
 When an IOMMU is transitioned to `Bare` of `Off` state, the IOMMU may retain
-information cached from in-memory data structures such as page tables in its
-address translation caches. Software must use suitable invalidation commands
-to invalidate cached entries.
+information cached from in-memory data structures such as page tables, DDT,
+PDT, etc. Software must use suitable invalidation commands to invalidate cached
+entries.
 
 [NOTE]
 ====

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -100,9 +100,7 @@ reset value for `ddtp.busy` field must be 0.
 
 Reset value for `tr_req_ctrl.Go/Busy` field must be 0.
 
-Reset state of address translation caches, device directory table entry
-caches, process directory table entry caches, and MSI page table entry caches
-is invalid.
+After a reset the caches (<<CACHING>>) must have no valid entries.
 
 [NOTE]
 ====

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -788,8 +788,21 @@ status of the command-queue.
 |31:28 |_custom_  |WPRI  | _Reserved for custom use._
 |===
 
-When `cmd_to`, `cmd_ill`, or `cqmf` is 1 in `cqcsr` the `cqh` references the
-command in the CQ that caused these error.
+When `cmd_ill` or `cqmf` is 1 in `cqcsr` the `cqt` references the command in the
+CQ that caused these error. Previous commands may have completed, timed out, or
+their execution aborted by the IOMMU.
+
+[NOTE]
+====
+If software makes the CQ operational again after a `cmd_ill` or `cqmf` error,
+then software should resubmit the commands submitted since the last `IOFENCE.C`
+that successfully completed.
+====
+
+The `cmd_to` bit is set when a `IOFENCE.C` command detects that one or more
+previous commands that are specified to have timeouts have timed out but all
+other commands previous to the `IOFENCE.C` have completed. When `cmd_to` is 1
+`cqt` references the `IOFENCE.C` command that detected the timeout.
 
 [NOTE]
 ====

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -6,7 +6,18 @@ registers of each IOMMU are located within a naturally aligned 4-KiB region
 
 The IOMMU behavior for register accesses where the address is not aligned to 
 the size of the access, or if the access spans multiple registers, of if the
-size of the access is not 4 bytes or 8 bytes, is `UNSPECIFIED`.
+size of the access is not 4 bytes or 8 bytes, is `UNSPECIFIED`. The atomicity
+of access to a 8 byte register is `UNSPECIFIED`. The implementation may
+observe the 8 byte access as two 4 byte accesses. A 4 byte access to an IOMMU
+register must be single-copy atomic.
+
+[NOTE]
+====
+If an implementation may observe a 8 byte register access as two 4 byte
+accesses then such implementations must preserve the semantics of the 8 byte
+access and must cause any side effects only after both accesses have been
+observed.
+====
 
 The IOMMU registers have little-endian byte order (even for systems where
 all harts are big-endian-only).
@@ -18,45 +29,6 @@ the `REV8` byte-reversal instruction defined by the Zbb extension. If `REV8` is
 not implemented, then endianness conversion may be implemented using a sequence
 of instructions.
 ====
-
-Register fields are assigned one of the attributes described in following 
-table.
-
-.Register and Register bit-field types
-[width=90%]
-[%header, cols="^3, 10"]
-|===
-^|Attribute    ^|                      Description
-| RW            | Read-Write - Register bits are read-write and are permitted 
-                  to be either Set or Cleared by software to the desired state.
-
-                  If the optional feature that is associated with the bits is 
-                  not implemented, the bits are permitted to be hardwired to
-                  Zero.
-| RW1S          | Read-Write-1-to-set - Register bits indicate status when
-                  read. The bit may be Set by writing 1b. Writing a 0b to RW1S
-                  bits has no effect.
-
-                  If the optional feature that introduces the bit is not 
-                  implemented, the bit must be read-only and hardwired to Zero
-| RO            | Read-only - Register bits are read-only and cannot be altered
-                  by software. Where explicitly defined, these bits are used
-                  to reflect changing hardware state, and as a result bit 
-                  values can be observed to change at run time.
-
-                  If the optional feature that would Set the bits is not 
-                  implemented, the bits must be hardwired to Zero
-| RW1C          | Write-1-to-clear status - Register bits indicate status when 
-                  read. A Set bit indicates a status event which is Cleared by
-                  writing a 1b. Writing a 0b to RW1C bits has no effect.
-
-                  If the optional feature that would Set the bit is not 
-                  implemented, the bit must be read-only and hardwired to Zero
-| WPRI          | Reserved Writes Preserve Values, Reads Ignore Values. See
-                  RISC-V privileged specification for a detailed definition.
-| WARL          | Write Any Values, Reads Legal Values. See RISC-V privileged 
-                  specification for a detailed definition.
-|===
 
 If a register is optional, as determined by the corresponding `capabilities`
 register bit being 0, then a read from the memory mapped register offset of 
@@ -128,6 +100,10 @@ reset value for `ddtp.busy` field must be 0.
 
 Reset value for `tr_req_ctrl.Go/Busy` field must be 0.
 
+Reset state of address translation caches, device directory table entry
+caches, process directory table entry caches, and MSI page table entry caches
+is invalid.
+
 [NOTE]
 ====
 The reset value for the `iommu_mode` is recommended to be `Off`.
@@ -185,9 +161,9 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
                                 hold the major version of the specification. 
                                 For example, an implementation that supports 
                                 version 1.0 of the specification reports 0x10.
-|8     |`Sv32`     |RO        | Page-based 32-bit virtual addressing is supported
-|9     |`Sv39`     |RO        | Page-based 39-bit virtual addressing is supported
-|10    |`Sv48`     |RO        | Page-based 48-bit virtual addressing is supported +
+|8     |`Sv32`     |RO        | Page-based 32-bit virtual addressing is supported.
+|9     |`Sv39`     |RO        | Page-based 39-bit virtual addressing is supported.
+|10    |`Sv48`     |RO        | Page-based 48-bit virtual addressing is supported. +
                                 When `Sv48` field is set, `Sv39` field must be set.
 |11    |`Sv57`     |RO        | Page-based 57-bit virtual addressing is supported +
                                 When `Sv57` field is set, `Sv48` field must be set.
@@ -240,6 +216,12 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
 |63:48 |_custom_   |RO        | _Reserved for custom use_
 |===
 
+If `HPM` is supported then the IOMMU must implement the cycles counter and at
+least 1 hardware performance monitoring counter must be implemented.
+
+At least one method, `MSI` or `WIS`, of generating interrupts from the IOMMU
+must be supported.
+
 [NOTE]
 ====
 Hypervisor may provide an SW emulated IOMMU to allow the guest to manage 
@@ -254,6 +236,13 @@ A hypervisor that provides such an emulated IOMMU to the guest may retain
 control of the MSI page tables used to direct MSI to guest interrupt files in 
 an IMSIC or to a memory-resident-interrupt-file and clear the `MSI_FLAT` and 
 `MSI_MRIF` fields of the emulated `capabilities` register.
+====
+
+[NOTE]
+====
+The `AMO` bit does not indicate support for device initiated atomic memory
+operations. Support for device initiated atomic memory operations must be
+discovered through other means.
 ====
 
 [[FCTRL]]
@@ -368,7 +357,7 @@ All IOMMU must support `Off` and `Bare` mode. An IOMMU is allowed to support a
 subset of directory-table levels and device-context widths. At a minimum one 
 of the modes must be supported.
 
-When the `iommu_mode` field value is changed `Off` the IOMMU guarantees that 
+When the `iommu_mode` field value is changed to `Off` the IOMMU guarantees that 
 in-flight transactions from devices connected to the IOMMU will be processed 
 with the configurations applicable to the old value of the `iommu_mode` field 
 and that all transactions and previous requests from devices that have already 
@@ -380,15 +369,15 @@ the previous value of the `iommu_mode` is not `Off` or `Bare` is `UNSPECIFIED`.
 To change DDT levels, the IOMMU must first be transitioned to `Bare` or `Off` 
 state.
 
+When an IOMMU is transitioned to `Bare` of `Off` state, the IOMMU may retain
+information cached from in-memory data structures such as page tables in its
+address translation caches. Software must use suitable invalidation commands
+to invalidate cached entries.
+
 [NOTE]
 ====
-In RV32, memory-mapped writes to `ddtp` modify only one 32-bit part of the
-register. The following sequence may be used to update the register using two
-32-bit writes.
-
-* Write the low order 32-bits to update the `PPN`. In RV32, the `PPN` is 
-  upto 22-bits.
-* Write the high order 32-bits to update the `iommu_mode` if required.
+In RV32, only the low order 32-bits of the register (22-bit `PPN` and 
+4-bit `iommu_mode`) need to be written.
 ====
 
 [[CQB]]
@@ -714,8 +703,8 @@ status of the command-queue.
                             sets the `cqh` and `cqt` to 0. The command-queue 
                             may take some time to be active following setting 
                             the `cqen` to 1. When the command queue is active,
-                            the `cqon` bit reads 1.
-
+                            the `cqon` bit reads 1. +
+                                                                              +
                             When `cqen` is changed from 1 to 0, the command 
                             queue may stay active till the commands already 
                             fetched from the command-queue are being processed 
@@ -723,8 +712,8 @@ status of the command-queue.
                             the command-queue.  When the command-queue turns 
                             off, the `cqon` bit reads 0, `cqh` is set to 0, 
                             `cqt` is set to 0 and the `cqcsr` bits `cmd_ill`, 
-                            `cmd_to`, `cqmf`, `fence_w_ip` are set to 0.
-
+                            `cmd_to`, `cqmf`, `fence_w_ip` are set to 0. +
+                                                                              +
                             When the `cqon` bit reads 0, the IOMMU guarantees 
                             that no implicit memory accesses to the command 
                             queue are in-flight and the command-queue will not 
@@ -782,22 +771,26 @@ status of the command-queue.
 |17   |`busy`   |RO       | A write to `cqcsr` may require the IOMMU to perform
                             many operations that may not occur synchronously 
                             to the write. When a write is observed by the 
-                            `cqcsr`, the `busy` bit is set to 1.
-
+                            `cqcsr`, the `busy` bit is set to 1. +
+                                                                               +
                             When the `busy` bit is 1, behavior of additional 
                             writes to the `cqcsr` is `UNSPECIFIED`. 
                             Some implementations may ignore the second write and
                             others may perform the actions determined by the 
-                            second write.
-
+                            second write. +
+                                                                               +
                             Software must verify that the busy bit is 0 before 
-                            writing to the `cqcsr`.
-
+                            writing to the `cqcsr`. +
+                                                                               +
                             An IOMMU that can complete these operations 
                             synchronously may hard-wire this bit to 0.
 |27:18 |`reserved`|WPRI  | Reserved for standard use
 |31:28 |_custom_  |WPRI  | _Reserved for custom use._
 |===
+
+When `cmd_to`, `cmd_ill`, or `cqmf` is 1 in `cqcsr` the `cqh` references the
+command in the CQ that caused these error.
+
 [NOTE]
 ====
 Command-queue being empty does not imply that all commands fetched from the 
@@ -837,21 +830,21 @@ status of the fault-queue.
 |===
 |Bits  |Field |Attribute | Description
 |0     |`fqen`|RW        | The fault-queue enable bit enables the fault-queue 
-                           when set to 1. 
-
+                           when set to 1. +
+                                                                               +
                            Changing `fqen`  from 0 to 1, resets the `fqh` and 
                            `fqt` to 0.
                            The fault-queue may take some time to be active
                            following setting the `fqen` to 1. When the fault 
-                           queue is active, the `fqon` bit reads 1.  
-
+                           queue is active, the `fqon` bit reads 1. +
+                                                                               +
                            When `fqen` is changed from 1 to 0, the fault-queue 
                            may stay active till in-flight fault-recording is 
                            completed. When the fault-queue is off, the `fqon` 
-                           bit reads 0, the `fqon` bit reads 0, `fqh` is set to 0,
-                           `fqt` is set to 0 and the `fqcsr` bits `fqof`, and
-                           `fqmf` are set to 0.
-
+                           bit reads 0, the `fqon` bit reads 0, `fqh` is set to
+                           0, `fqt` is set to 0 and the `fqcsr` bits `fqof`, and
+                           `fqmf` are set to 0. +
+                                                                               +
                            The IOMMU guarantees that there are no 
                            in-flight implicit writes to the fault-queue in 
                            progress when `fqon` reads 0 and no new fault 
@@ -869,8 +862,8 @@ status of the fault-queue.
                            masked (i.e. `fqsr.fie == 0`).
 |9     |`fqof`|RW1C      | The fault-queue-overflow bit is set to 1 if the 
                             IOMMU needs to queue a fault record but the 
-                            fault-queue is full (i.e., `fqh == fqt - 1`) 
-
+                            fault-queue is full (i.e., `fqh == fqt - 1`). +
+                                                                               +
                             The fault-record is discarded and no more fault 
                             records are generated till software clears `fqof` 
                             by writing 1 to the bit. An interrupt is generated 
@@ -892,11 +885,11 @@ status of the fault-queue.
                            of additional writes to the `fqcsr` are 
                            `UNSPECIFIED`. Some implementations may 
                            ignore the second write and others may perform the 
-                           actions determined by the second write.
-
+                           actions determined by the second write. +
+                                                                               +
                            Software should ensure that the `busy` bit is 0 
-                           before writing to the `fqcsr`. 
-
+                           before writing to the `fqcsr`. +
+                                                                               +
                            An IOMMU that can complete controls synchronously 
                            may hard-wire this bit to 0. 
 |27:18 |`reserved`|WPRI  | Reserved for standard use
@@ -932,27 +925,27 @@ status of the page-request-queue.
 |===
 |Bits  |Field    |Attribute | Description
 |0     |`pqen`   |RW        | The page-request-enable bit enables the
-                              page-request-queue when set to 1. 
-
+                              page-request-queue when set to 1. +
+                                                                               +
                               Changing `pqen` from 0 to 1, resets the `pqh` 
                               and `pqt` to 0 and clears `pqcsr` bits `pqmf` and
                               `pqof` to 0. The page-request-queue may take 
                               some time to be active following setting the 
                               `pqen` to 1. When the page-request-queue is 
-                              active, the `pqon` bit reads 1.
-
+                              active, the `pqon` bit reads 1. +
+                                                                               +
                               When `pqen` is changed from 1 to 0, the 
                               page-request-queue may stay active till in-flight 
                               page-request writes are completed. When the
                               page-request-queue turns off, the `pqon` bit 
                               reads 0, `pqh` is set to 0, `pqt` is set to 0 and 
-                              the `pqcsr` bits `pqof`, and `pqmf` are set to 0.
-
+                              the `pqcsr` bits `pqof`, and `pqmf` are set to 0. +
+                                                                               +
                               When `pqon` reads 0, the IOMMU guarantees that 
                               there are no older in-flight implicit writes to 
                               the queue memory and no further implicit writes 
-                              will be generated to the queue memory. 
-
+                              will be generated to the queue memory. +
+                                                                               +
                               The IOMMU may respond to “Page Request” messages 
                               received when page-request-queue is off or in 
                               the process of being turned off, as specified in
@@ -963,18 +956,18 @@ status of the page-request-queue.
 |7:2   |`reserved`|WPRI     | Reserved for standard use
 |8     |`pqmf`    |RW1C     | The `pqmf` bit is set to 1 if the IOMMU 
                               encounters an access fault when storing a 
-                              page-request message to the page-request-queue.
-
+                              page-request message to the page-request-queue. +
+                                                                               +
                               When `pqmf` is set to 1, an interrupt is 
                               generated if not already pending 
                               (i.e. `ipsr.pip == 1`) and not masked 
-                              (i.e. `pqsr.pie == 1`).
-
+                              (i.e. `pqsr.pie == 1`). +
+                                                                               +
                               The "Page Request" message that caused the `pqmf` 
                               or `pqof` error and all subsequent page-request 
                               messages are discarded till software clears the 
-                              `pqof` and/or `pqmf` bits by writing 1 to it. 
-
+                              `pqof` and/or `pqmf` bits by writing 1 to it. +
+                                                                               +
                               The IOMMU may respond to “Page Request” messages 
                               that caused the `pqof` or `pqmf` bit to be set 
                               and all subsequent “Page Request” messages 
@@ -984,26 +977,26 @@ status of the page-request-queue.
                               if the page-request queue overflows i.e. IOMMU 
                               needs to queue a page-request message but the 
                               page-request queue is full 
-                              (i.e., `pqh == pqt - 1`). 
-
+                              (i.e., `pqh == pqt - 1`). +
+                                                                               +
                               When `pqof` is set to 1, an interrupt is 
                               generated if not already pending 
                               (i.e. `ipsr.pip == 1`) and not masked 
-                              (i.e. `pqsr.pie == 1`).
-
+                              (i.e. `pqsr.pie == 1`). +
+                                                                               +
                               The "Page Request" message that caused the `pqmf` 
                               or `pqof` error and all subsequent page-request 
                               messages are discarded till software clears the 
-                              `pqof` and/or `pqmf` bits by writing 1 to it. 
-
+                              `pqof` and/or `pqmf` bits by writing 1 to it. +
+                                                                               +
                               The IOMMU may respond to “Page Request” messages 
                               that caused the `pqof` or `pqmf` bit to be set 
                               and all subsequent “Page Request” messages 
                               received while these bits are 1 as specified in
                               <<ATS_PRI>>.
 |15:10 |`reserved`|WPRI     | Reserved for standard use
-|16    |`pqon`    |RO       | The page-request is active when `pqon` reads 1.
-
+|16    |`pqon`    |RO       | The page-request is active when `pqon` reads 1. +
+                                                                               +
                               IOMMU behavior on changing `pqb` when `busy` is 1
                               or `pqon` is 1 is `UNSPECIFIED`. The 
                               recommended sequence to change `pqb` is to first 
@@ -1014,15 +1007,15 @@ status of the page-request-queue.
                               perform many operations that may not occur 
                               synchronously to the write. When a write is 
                               observed by the `pqcsr`, the `busy` bit is set 
-                              to 1.
-
+                              to 1. +
+                                                                               +
                               When the `busy` bit is 1, behavior of additional 
                               writes to the `pqcsr` are `UNSPECIFIED`.
                               Some implementations may ignore the second write 
                               and others may perform the actions determined by 
                               the second write. Software should ensure that the
-                              `busy` bit is 0 before writing to the `pqcsr`.
-
+                              `busy` bit is 0 before writing to the `pqcsr`. +
+                                                                               +
                               An IOMMU that can complete controls synchronously
                               may hard-wire this bit to 0
 |27:18 |`reserved`|WPRI     | Reserved for standard use
@@ -1068,9 +1061,9 @@ software clears that interrupt-pending bit by writing 1 to clear it.
 [[OVF]]
 === Performance-monitoring counter overflow status (`iocountovf`)
 The performance-monitoring counter overflow status is a 32-bit read-only
-register that contains shadow copies of the OF bits in the `iohpmevt1-31` registers
-- where `iocntovf` bit X corresponds to `iohpmevtX` and bit 0 corresponds to the
-`OF` bit of `iohpmcycles`.
+register that contains shadow copies of the OF bits in the `iohpmevt1-31`
+registers - where `iocntovf` bit X corresponds to `iohpmevtX` and bit 0
+corresponds to the `OF` bit of `iohpmcycles`.
 
 This register enables overflow interrupt handler software to quickly and easily
 determine which counter(s) have overflowed.
@@ -1487,8 +1480,8 @@ translation-request interface for debug. This register is present when
 | 0     |`Go/Busy`  |RW1S      | This bit is set to indicate a valid 
                                  request has been setup in the 
                                  `tr_req_iova/tr_req_ctrl` registers
-                                 for the IOMMU to translate.
-                                 
+                                 for the IOMMU to translate. +
+                                                                               +
                                  The IOMMU indicates completion of the
                                  requested translation by clearing this
                                  bit to 0. On completion, the results 

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -472,7 +472,7 @@ the software queues the next command for the IOMMU.
 |Bits |Field   |Attribute | Description
 |31:0 |`index` |WARL      | Holds the `index` into the command-queue where 
                             software queues the next command for IOMMU.  Only 
-                            `LOG2SZ:0` bits are writable.
+                            `LOG2SZ-1:0` bits are writable.
 |===
 
 [[FQB]]
@@ -545,7 +545,7 @@ software will fetch the next fault record.
 |Bits |Field   |Attribute |Description
 |31:0 |`index` |WARL      | Holds the `index` into the fault-queue from which 
                             software reads the next fault record.  Only 
-                            `LOG2SZ:0` bits are writable.
+                            `LOG2SZ-1:0` bits are writable.
 |===
 
 [[FQT]]
@@ -643,7 +643,7 @@ software will fetch the next page-request.
 |Bits |Field   |Attribute | Description
 |31:0 |`index` |WARL      | Holds the `index` into the page-request-queue from 
                             which software reads the next "Page Request" message.
-                            Only `LOG2SZ:0` bits are writable.
+                            Only `LOG2SZ-1:0` bits are writable.
 |===
 
 [[PQT]]


### PR DESCRIPTION
1. Deleted register field attributes table as it is also in the terms and definition and was repeated
2. Clarified that a 8 byte register access may not be single-copy atomic but implementation must not cause side effects till both halves are written. Clarified that 4 byte accesses must be single copy atomic.
3. Clarified reset value of caches
4. Moved the HPM and interrupt generation requirements from feature list in intro to the capabilities register subsection
5. Clarified that turning IOMMU off or bare is not required to auto invalidate caches
6. Updated RV32 note for ddtp as with new layout it was stale
7. Clarified that when cmd queu error bits are set then the cqh is required to point to the command that caused the error.
8. Fixed line breaks in various table rows.