### PR TITLE
Pull request to address issue #27

### DIFF
--- a/iommu_data_structures.adoc
+++ b/iommu_data_structures.adoc
@@ -569,6 +569,54 @@ the address mask.
 ], config:{lanes: 2, hspace: 1024, fontsize: 16}}
 ....
 
+[[DC_MISCONFIG]]
+==== Device-context configuration checks
+
+A `DC` with `V=1` is considered as misconfigured if any of the following
+conditions are true.
+
+. If any bits or encoding that are reserved for future standard use are set
+  within `DC`, stop and report "DDT entry misconfigured" (cause = 259).
+. `capabilities.ATS` is 0 and `DC.tc.EN_ATS`, or `DC.tc.EN_PRI`,
+   or `DC.tc.PRPR` is 1
+. `DC.tc.EN_ATS` is 0 and `DC.tc.T2GPA` is 1
+. `DC.tc.EN_ATS` is 0 and `DC.tc.EN_PRI` is 1
+. `DC.tc.EN_PRI` is 0 and `DC.tc.PRPR` is 1
+. `capabilities.T2GPA` is 0 and `DC.tc.T2GPA` is 1
+. `DC.tc.PDTV` is 1 and `DC.fsc.pdtp.MODE` is not a supported mode
+.. `capabilities.PD20` is 0 and `DC.fsc.pdtp.MODE` is `PD20`
+.. `capabilities.PD17` is 0 and `DC.fsc.pdtp.MODE` is `PD17`
+.. `capabilities.PD8` is 0 and `DC.fsc.pdtp.MODE` is `PD8`
+. `DC.tc.PDTV` is 0 and `DC.fsc.iosatp.MODE` is not one of the
+   supported modes
+.. `capabilities.Sv32` is 0 and `DC.fsc.iosatp.MODE` is `Sv32`
+.. `capabilities.Sv39` is 0 and `DC.fsc.iosatp.MODE` is `Sv39`
+.. `capabilities.Sv48` is 0 and `DC.fsc.iosatp.MODE` is `Sv48`
+.. `capabilities.Sv57` is 0 and `DC.fsc.iosatp.MODE` is `Sv57`
+. `capabilities.Sv32x4` is 0 and `DC.iohgatp.MODE` is `Sv32x4`
+. `capabilities.Sv39x4` is 0 and `DC.iohgatp.MODE` is `Sv39x4`
+. `capabilities.Sv48x4` is 0 and `DC.iohgatp.MODE` is `Sv48x4`
+. `capabilities.Sv57x4` is 0 and `DC.iohgatp.MODE` is `Sv57x4`
+. `capabilities.MSI_FLAT` is 1 and `DC.msiptp.MODE` is not `Bare`
+   and not `Flat`
+. `DC.iohgatp.MODE` is not `Bare` and the root page table determined by
+  `DC.iohgatp.PPN` is not aligned to a 16-KiB boundary.
+. `capabilities.AMO` is 0 and `DC.tc.SADE` or `DC.tc.GADE` is 1
+
+[NOTE]
+====
+Some `DC` fields that hold a system-physical-addresses or
+guest-physical-addresses. Some implementations may verify the validity of the
+addresses - e.g. the system-physical-address is not wider than that supported as
+determined by `capabilities.PAS`, etc. at the time of locating the `DC`. Such
+implementations may cause a "DDT entry misconfigured" (cause = 259) fault.
+
+Other implementations only detect such addresses to be invalid when the data
+structure referenced by these fields need to be accessed. Such
+implementations may detect access-violation faults in the process of making the
+acccess.
+====
+
 === Process-Directory-Table (PDT)
 
 The PDT is a 1, 2, or 3-level radix tree indexed using the process directory

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -106,7 +106,7 @@ the register returns 0 and writes to that offset are ignored.
                                      response>>           | if `capabilities.DBG==0`
 |624   |Reserved        |64  |Reserved for future use
                               (`WPRI`)                    |
-|682   |_custom_        |72  |_Reserved for custom use
+|688   |_custom_        |72  |_Reserved for custom use
                               (`WARL`)_                   |
 |760   |`icvec`         |4   |<<ICVEC, Interrupt cause
                               to vector register>>        | No

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -104,9 +104,9 @@ the register returns 0 and writes to that offset are ignored.
                                      control>>            | if `capabilities.DBG==0`
 |616   |`tr_response`   |8   |<<TRR_RSP,Translation-request
                                      response>>           | if `capabilities.DBG==0`
-|624   |Reserved        |58  |Reserved for future use
+|624   |Reserved        |64  |Reserved for future use
                               (`WPRI`)                    |
-|682   |_custom_        |78  |_Reserved for custom use
+|682   |_custom_        |72  |_Reserved for custom use
                               (`WARL`)_                   |
 |760   |`icvec`         |4   |<<ICVEC, Interrupt cause
                               to vector register>>        | No

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -169,8 +169,11 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
   {bits: 1, name: 'HPM'},
   {bits: 1, name: 'DBG'},
   {bits: 6, name: 'PAS'},
-  {bits: 10, name: 'reserved'},
-  {bits: 16, name: 'custom'},
+  {bits: 1, name: 'PD20'},
+  {bits: 1, name: 'PD17'},
+  {bits: 1, name: 'PD8'},
+  {bits: 15, name: 'reserved'},
+  {bits: 8, name: 'custom'},
 ], config:{lanes: 8, hspace:1024}}
 ....
 
@@ -236,9 +239,17 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
 |30    |`HPM`     |RO         | IOMMU implements a hardware performance monitor.
 |31    |`DBG`      |RO        | IOMMU supports the translation-request interface
 |37:32 |`PAS`      |RO        | Physical Address Size (value between 32 and 56)
-|47:38 | reserved  |RO        | Reserved for standard use
-|63:48 |_custom_   |RO        | _Reserved for custom use_
+|38    |`PD20`     |RO        | Three level PDT with 20-bit process_id supported.
+|39    |`PD17`     |RO        | Two level PDT with 17-bit process_id supported.
+|40    |`PD8`      |RO        | One level PDT with 8-bit process_id supported.
+|55:41 | reserved  |RO        | Reserved for standard use
+|63:56 |_custom_   |RO        | _Reserved for custom use_
 |===
+
+The implementation must support a `PSCID` that is at least as wide as the 
+supported `process_id` width. The behavior of configuring a `PSCID` in in-memory
+data structures and registers that is wider than the supported `process_id`
+width is `UNSPECIFIED`.
 
 [NOTE]
 ====

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -246,11 +246,6 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
 |63:56 |_custom_   |RO        | _Reserved for custom use_
 |===
 
-The implementation must support a `PSCID` that is at least as wide as the 
-supported `process_id` width. The behavior of configuring a `PSCID` in in-memory
-data structures and registers that is wider than the supported `process_id`
-width is `UNSPECIFIED`.
-
 [NOTE]
 ====
 Hypervisor may provide an SW emulated IOMMU to allow the guest to manage 

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -169,9 +169,9 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
   {bits: 1, name: 'HPM'},
   {bits: 1, name: 'DBG'},
   {bits: 6, name: 'PAS'},
-  {bits: 1, name: 'PD20'},
-  {bits: 1, name: 'PD17'},
   {bits: 1, name: 'PD8'},
+  {bits: 1, name: 'PD17'},
+  {bits: 1, name: 'PD20'},
   {bits: 15, name: 'reserved'},
   {bits: 8, name: 'custom'},
 ], config:{lanes: 8, hspace:1024}}
@@ -239,9 +239,9 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
 |30    |`HPM`     |RO         | IOMMU implements a hardware performance monitor.
 |31    |`DBG`      |RO        | IOMMU supports the translation-request interface
 |37:32 |`PAS`      |RO        | Physical Address Size (value between 32 and 56)
-|38    |`PD20`     |RO        | Three level PDT with 20-bit process_id supported.
+|38    |`PD8`      |RO        | One level PDT with 8-bit process_id supported.
 |39    |`PD17`     |RO        | Two level PDT with 17-bit process_id supported.
-|40    |`PD8`      |RO        | One level PDT with 8-bit process_id supported.
+|40    |`PD20`     |RO        | Three level PDT with 20-bit process_id supported.
 |55:41 | reserved  |RO        | Reserved for standard use
 |63:56 |_custom_   |RO        | _Reserved for custom use_
 |===


### PR DESCRIPTION
1. 3 capability bits added to enumerate PD20, PD17, PD8
2. Device context configuration checks updated to check supported PDTP mode
3. If PSCID wider than supported process_id width then behavior is UNSPECIFIED