### PR TITLE
Pull request to address issue 46

### DIFF
--- a/iommu_in_memory_queues.adoc
+++ b/iommu_in_memory_queues.adoc
@@ -553,11 +553,25 @@ as defined by the `CAUSE`.
 and if the privilege of the transaction was Supervisor then `PRIV` bit is 1 
 else its 0. The `DID`, `PV`, `PID`, and `PRIV` fields are 0 if `TTYP` is 0.
 
-If the `CAUSE` is a guest-page fault then the guest-physical-address right 
-shifted by 2 is reported in `iotval2[63:2]`. If bit 0 of `iotval2` is 1, then 
-guest-page-fault was caused by an implicit memory access for VS-stage address
-translation. If bit 0 of `iotval2` is 1, and the implicit access was a write
-then bit 1 of `iotval2` is set to 1 else it is set to 0.
+If the `CAUSE` is a guest-page fault then bits 63:2 of the zero-extended
+guest-physical-address are reported in `iotval2[63:2]`. If bit 0 of `iotval2` is
+1, then guest-page-fault was caused by an implicit memory access for VS-stage
+address translation. If bit 0 of `iotval2` is 1, and the implicit access was a
+write then bit 1 of `iotval2` is set to 1 else it is set to 0.
+
+[NOTE]
+====
+The bit 1 of `iotval2` is set for the case where the implementation supports
+hardware updating of A/D bits and the implicit memory access was attempted to
+automatically update A and/or D in VS-stage page tables. All other implicit
+memory accesses for VS-stage address translation will be reads. If the hardware
+updating of A/D bits is not implemented, the _write_ case will never arise.
+
+When the G-stage is active, the memory accesses for reading PDT entries to
+locate the Process-context are implicit memory accesses for VS-stage address
+translation. If a guest-page fault was caused by implicit memory access to read
+PDT entries, then the bit 0 of `iotval2` is reported as 1 and the bit 1 as 0.
+====
 
 The IOMMU may be unable to report faults through the fault-queue due to error 
 conditions such as the fault-queue being full or the IOMMU encountering access


### PR DESCRIPTION
1. Updated wordings for iotval2 reporting
2. Added note about when write ase of iotval2 occurs
3. Added note that PDT accesses when G-stage is active are implicit.