### PR TITLE
Disambiguate fctl term

### DIFF
--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -272,7 +272,7 @@ allow one or more fields in the register to be writable to support enabling
 or disabling the feature controlled by that field.
 
 If software enables or disables a feature when the IOMMU is not OFF
-(i.e. `ddtp.iommu_mode == Off`) then the IOMMU behavior is `UNSPECIFIED`.
+(i.e. when `ddtp.iommu_mode != Off`) then the IOMMU behavior is `UNSPECIFIED`.
 
 If software enables or disables a feature when the IOMMU in-memory queues
 are enabled (i.e. `cqcsr.cqon/cqen == 1`, `fqcsr.fqon/cqen == 1`, or


### PR DESCRIPTION
Minor nit: It wasn't perfectly clear whether the parenthetical term was describing "OFF" or "not OFF".  This change clearly describes the latter.
