### PR TITLE
Migrate to Node 16

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
     - name: Set outputs.name
       id: step1
-      run: echo "::set-output name=name::$NAME"
+      run: echo "name=$NAME" >> $GITHUB_OUTPUT
     - name: Set outputs.pdf-name
       id: step2
-      run: echo "::set-output name=pdf-name::$NAME.pdf"
+      run: echo "pdf-name=$NAME.pdf" >> $GITHUB_OUTPUT
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Install Ubuntu packages
@@ -55,16 +55,16 @@ jobs:
         ruby-version: "2.6"
         bundler-cache: true
     # Node.js for wavedrom
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install Node.js dependencies
       run: npm install ${NPM_PACKAGE_FOLDER}
     - name: Generate PDF
@@ -72,7 +72,7 @@ jobs:
         PATH=${PATH}:${BUNDLE_BIN}:$(npm bin) \
         make
     - name: Archive PDF result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.NAME }}.pdf
         path: ${{ env.NAME }}.pdf

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,27 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ github.event.inputs.version }}
-        release_name: Release ${{ github.event.inputs.version }}
-        draft: ${{ github.event.inputs.draft }}
-        prerelease: ${{ github.event.inputs.prerelease }}
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ needs.build.outputs.pdf-name }}
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path:  ${{ needs.build.outputs.pdf-name }}
-        asset_name:  ${{ needs.build.outputs.name }}_${{ github.event.inputs.version }}.pdf
-        asset_content_type: application/pdf
+        files: ${{ needs.build.outputs.pdf-name }}
+        tag_name: v${{ github.event.inputs.version }}
+        name: Release ${{ github.event.inputs.version }}
+        draft: ${{ github.event.inputs.draft }}
+        prerelease: ${{ github.event.inputs.prerelease }}


### PR DESCRIPTION
- Updates to GH actions in workflow to eliminate deprecation warnings
- Update to workflow to remove Node 12 deprecated assignments
- Update nodejs version to v16