### PR TITLE
Update IOMMU ref model with option to cache ATS translations in IOMMU ATC

### DIFF
--- a/iommu_ref_model/libiommu/include/iommu_atc.h
+++ b/iommu_ref_model/libiommu/include/iommu_atc.h
@@ -66,7 +66,7 @@ cache_ioatc_iotlb(
 
 extern uint8_t
 lookup_ioatc_iotlb(
-    uint64_t iova,
+    uint64_t iova, uint8_t check_access_perms,
     uint8_t priv, uint8_t is_read, uint8_t is_write, uint8_t is_exec,
     uint8_t SUM, uint8_t PSCV, uint32_t PSCID, uint8_t GV, uint16_t GSCID, 
     uint32_t *cause, uint64_t *resp_pa, uint64_t *page_sz,

--- a/iommu_ref_model/libiommu/include/iommu_ref_api.h
+++ b/iommu_ref_model/libiommu/include/iommu_ref_api.h
@@ -15,7 +15,8 @@ extern int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_ma
                        uint8_t num_vec_bits, uint8_t reset_iommu_mode, 
                        uint8_t max_iommu_mode, uint32_t max_devid_mask,
                        uint8_t gxl_writeable, uint8_t fctl_be_writeable,
-                       capabilities_t capabilities, fctl_t fctl);
+                       uint8_t fill_ats_trans_in_ioatc, capabilities_t capabilities,
+                       fctl_t fctl);
 extern void iommu_translate_iova(hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp_msg);
 extern void handle_page_request(ats_msg_t *pr);
 extern uint8_t handle_invalidation_completion(ats_msg_t *inv_cc);

--- a/iommu_ref_model/libiommu/include/iommu_ref_api.h
+++ b/iommu_ref_model/libiommu/include/iommu_ref_api.h
@@ -11,6 +11,9 @@ extern uint8_t write_memory(char *data, uint64_t address, uint32_t size);
 
 extern uint64_t read_register(uint16_t offset, uint8_t num_bytes);
 extern void write_register(uint16_t offset, uint8_t num_bytes, uint64_t data);
+
+#define FILL_IOATC_ATS_T2GPA  0x01
+#define FILL_IOATC_ATS_ALWAYS 0x02
 extern int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_mask, 
                        uint8_t num_vec_bits, uint8_t reset_iommu_mode, 
                        uint8_t max_iommu_mode, uint32_t max_devid_mask,

--- a/iommu_ref_model/libiommu/include/iommu_registers.h
+++ b/iommu_ref_model/libiommu/include/iommu_registers.h
@@ -787,6 +787,7 @@ extern uint8_t g_gxl_writeable;
 extern uint8_t g_fctl_be_writeable;
 extern uint8_t offset_to_size[4096];
 extern uint8_t g_max_iommu_mode;
+extern uint8_t g_fill_ats_trans_in_ioatc;
 extern uint32_t g_max_devid_mask;
 
 extern void process_commands(void);

--- a/iommu_ref_model/libiommu/src/iommu_atc.c
+++ b/iommu_ref_model/libiommu/src/iommu_atc.c
@@ -144,7 +144,7 @@ cache_ioatc_iotlb(
 // Lookup a translation in the IOATC
 uint8_t
 lookup_ioatc_iotlb(
-    uint64_t iova,
+    uint64_t iova, uint8_t check_access_perms,
     uint8_t priv, uint8_t is_read, uint8_t is_write, uint8_t is_exec,
     uint8_t SUM, uint8_t PSCV, uint32_t PSCID, uint8_t GV, uint16_t GSCID, 
     uint32_t *cause, uint64_t *resp_pa, uint64_t *page_sz,
@@ -169,9 +169,11 @@ lookup_ioatc_iotlb(
     tlb[i].lru = tlb_lru_time++;
 
     // Check S/VS stage permissions
-    if ( is_exec  && (tlb[hit].VS_X == 0) ) goto page_fault;
-    if ( is_read  && (tlb[hit].VS_R == 0) ) goto page_fault;
-    if ( is_write && (tlb[hit].VS_W == 0) ) goto page_fault;
+    if ( check_access_perms == 1 ) {
+        if ( is_exec  && (tlb[hit].VS_X == 0) ) goto page_fault;
+        if ( is_read  && (tlb[hit].VS_R == 0) ) goto page_fault;
+        if ( is_write && (tlb[hit].VS_W == 0) ) goto page_fault;
+    }
     if ( (priv == U_MODE) && (tlb[hit].U == 0) ) goto page_fault;
     if ( is_exec && (priv == S_MODE) && (tlb[hit].U == 1) ) goto page_fault;
     if ( (priv == S_MODE) && !is_exec && SUM == 0 && tlb[hit].U == 1 ) goto page_fault;

--- a/iommu_ref_model/libiommu/src/iommu_reg.c
+++ b/iommu_ref_model/libiommu/src/iommu_reg.c
@@ -17,6 +17,7 @@ uint8_t g_num_vec_bits;
 uint8_t g_gxl_writeable;
 uint8_t g_fctl_be_writeable;
 uint8_t g_max_iommu_mode;
+uint8_t g_fill_ats_trans_in_ioatc;
 uint32_t g_max_devid_mask;
 
 uint8_t 
@@ -818,7 +819,8 @@ reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_mask,
             uint8_t num_vec_bits, uint8_t reset_iommu_mode, 
             uint8_t max_iommu_mode, uint32_t max_devid_mask,
             uint8_t gxl_writeable, uint8_t fctl_be_writeable,
-            capabilities_t capabilities, fctl_t fctl) {
+            uint8_t fill_ats_trans_in_ioatc, capabilities_t capabilities,
+            fctl_t fctl) {
     int i;
 #ifdef DEBUG
     // Only PA upto 56 bits supported in RISC-V
@@ -840,7 +842,7 @@ reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_mask,
     if ( g_eventID_mask != 0 && capabilities.hpm == 0 )
         return -1; 
     // vectors is a number between 1 and 15
-    if ( num_vec_bits > 4 )
+     ( num_vec_bits > 4 )
         return -1;
     // Number of HPM counters must be between 0 and 31
     // If perfmon is not supported then should be 0
@@ -866,6 +868,7 @@ reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_mask,
     g_fctl_be_writeable = fctl_be_writeable;
     g_max_iommu_mode = max_iommu_mode;
     g_max_devid_mask = max_devid_mask;
+    g_fill_ats_trans_in_ioatc = fill_ats_trans_in_ioatc;
     
     // Initialize registers that have resets to 0
     // The reset default value is 0 for the following registers. 

--- a/iommu_ref_model/libiommu/src/iommu_reg.c
+++ b/iommu_ref_model/libiommu/src/iommu_reg.c
@@ -842,7 +842,7 @@ reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_mask,
     if ( g_eventID_mask != 0 && capabilities.hpm == 0 )
         return -1; 
     // vectors is a number between 1 and 15
-     ( num_vec_bits > 4 )
+    if ( num_vec_bits > 4 )
         return -1;
     // Number of HPM counters must be between 0 and 31
     // If perfmon is not supported then should be 0

--- a/iommu_ref_model/libiommu/src/iommu_translate.c
+++ b/iommu_ref_model/libiommu/src/iommu_translate.c
@@ -365,11 +365,12 @@ skip_gpa_trans:
                           &vs_pte, &g_pte, napot_ppn, ((page_sz > PAGESIZE) ? 1 : 0));
     } 
     if ( (TTYP == PCIE_ATS_TRANSLATION_REQUEST) &&
-         ((DC.tc.T2GPA == 1) || (g_fill_ats_trans_in_ioatc == 1)) ) {
+         ((DC.tc.T2GPA == 1 && ((g_fill_ats_trans_in_ioatc & FILL_IOATC_ATS_T2GPA) != 0) ) || 
+          ((g_fill_ats_trans_in_ioatc & FILL_IOATC_ATS_ALWAYS) != 0)) ) {
         // If in T2GPA mode, cache the final GPA->SPA translation as 
         // the translated requests may hit on this 
         // If T2GPA is 0, then cache the IOVA->SPA translation if
-        // IOMMU has been configured to do so i.e. g_fill_ats_trans_in_ioatc is 1
+        // IOMMU has been configured to do so
         cache_ioatc_iotlb((DC.tc.T2GPA == 1) ? napot_gpa : napot_iova,
                                      GV, (DC.tc.T2GPA == 1) ? 0 : PSCV,
                           iohgatp.GSCID, (DC.tc.T2GPA == 1) ? 0 : PSCID,

--- a/iommu_ref_model/libiommu/src/iommu_two_stage_trans.c
+++ b/iommu_ref_model/libiommu/src/iommu_two_stage_trans.c
@@ -7,7 +7,7 @@
 
 uint8_t
 two_stage_address_translation(
-    uint64_t iova, uint8_t TTYP, uint32_t DID, uint8_t is_read,
+    uint64_t iova, uint8_t check_access_perms, uint32_t DID, uint8_t is_read,
     uint8_t is_write, uint8_t is_exec,
     uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
     iosatp_t iosatp, uint8_t priv, uint8_t SUM, uint8_t SADE,
@@ -204,7 +204,7 @@ step_5:
     //   read permission to be granted if the execute permission is granted.
     //   No faults are caused here - the denied permissions will be reported back in
     //   the ATS completion
-    if ( TTYP != PCIE_ATS_TRANSLATION_REQUEST ) {
+    if ( check_access_perms == 1 ) {
         if ( is_exec  && (pte->X == 0) ) goto page_fault;
         if ( is_read  && (pte->R == 0) ) goto page_fault;
         if ( is_write && (pte->W == 0) ) goto page_fault;

--- a/iommu_ref_model/test/test_app.c
+++ b/iommu_ref_model/test/test_app.c
@@ -67,7 +67,10 @@ main(void) {
     cap.dbg = 1;
     cap.pas = 50;
     cap.pd20 = cap.pd17 = cap.pd8 = 1;
-    fail_if( ( reset_iommu(8, 40, 0xff, 3, Off, DDT_3LVL, 0xFFFFFF, 0, 0, 1, cap, fctl) < 0 ) );
+
+    fail_if( ( reset_iommu(8, 40, 0xff, 3, Off, DDT_3LVL, 0xFFFFFF, 0, 0, 
+                           (FILL_IOATC_ATS_T2GPA | FILL_IOATC_ATS_ALWAYS),
+                           cap, fctl) < 0 ) );
     for ( i = MSI_ADDR_0_OFFSET; i <= MSI_ADDR_7_OFFSET; i += 16 ) {
         write_register(i, 8, 0xFF);
         fail_if(( read_register(i, 8) != 0xFc ));


### PR DESCRIPTION
In some cases it is beneficial to cache responses provided in ATS translation completions in IOMMU ATC. This is currently done only when T2GPA is 1. This PR updates it to add the support for doing caching for T2GPA=0 case as well.