### PR TITLE
Errata Fixes

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -22,8 +22,9 @@
 :lang: en
 :listing-caption: Listing
 :sectnums:
+:sectnumlevels: 5
 :toc: left
-:toclevels: 4
+:toclevels: 5
 :source-highlighter: pygments
 ifdef::backend-pdf[]
 :source-highlighter: coderay

--- a/iommu_data_structures.adoc
+++ b/iommu_data_structures.adoc
@@ -84,25 +84,25 @@ traverse the DDT radix-tree are as follows:
 
 .Base format `device_id` partitioning
 
-[wavedrom, , ]
-....
-{reg: [
-  {bits: 7, name: 'DDI[0]'},
-  {bits: 9, name: 'DDI[1]'},
-  {bits: 8, name: 'DDI[2]'},
-], config:{lanes: 1, hspace:1024, fontsize: 16}}
-....
+//[wavedrom, , ]
+//....
+//{reg: [
+//  {bits: 7, name: 'DDI[0]'},
+//  {bits: 9, name: 'DDI[1]'},
+//  {bits: 8, name: 'DDI[2]'},
+//], config:{lanes: 1, hspace:1024, fontsize: 16}}
+//....
 
 .Extended format `device_id` partitioning
 
-[wavedrom, , ]
-....
-{reg: [
-  {bits: 6, name: 'DDI[0]'},
-  {bits: 9, name: 'DDI[1]'},
-  {bits: 9, name: 'DDI[2]'},
-], config:{lanes: 1, hspace:1024, fontsize: 16}}
-....
+//[wavedrom, , ]
+//....
+//{reg: [
+//  {bits: 6, name: 'DDI[0]'},
+//  {bits: 9, name: 'DDI[1]'},
+//  {bits: 9, name: 'DDI[2]'},
+//], config:{lanes: 1, hspace:1024, fontsize: 16}}
+//....
 
 The PDT may be configured to be a 1, 2, or 3 level radix-tree depending on the
 maximum width of the `process_id` supported by that device.  The partitioning
@@ -111,14 +111,14 @@ the PDT radix-tree are as follows:
 
 .`process_id` partitioning for PDT radix-tree traversal
 
-[wavedrom, , ]
-....
-{reg: [
-  {bits: 8, name: 'PDI[0]'},
-  {bits: 9, name: 'PDI[1]'},
-  {bits: 3, name: 'PDI[2]'},
-], config:{lanes: 1, hspace:1024, fontsize: 16}}
-....
+//[wavedrom, , ]
+//....
+//{reg: [
+//  {bits: 8, name: 'PDI[0]'},
+//  {bits: 9, name: 'PDI[1]'},
+//  {bits: 3, name: 'PDI[2]'},
+//], config:{lanes: 1, hspace:1024, fontsize: 16}}
+//....
 [NOTE]
 ====
 The `process_id` partitioning is designed to require a maximum of 4 KiB, a
@@ -203,15 +203,15 @@ A valid (`V==1`) non-leaf DDT entry provides the PPN of the next level DDT.
 
 .Non-leaf device-directory-table entry
 
-[wavedrom, , ]
-....
-{reg: [
-  {bits: 1,  name: 'V',        attr: '1'},
-  {bits: 9, name: 'reserved', attr: '9'},
-  {bits: 44, name: 'PPN',      attr: '44'},
-  {bits: 10,  name: 'reserved', attr: '10'},
-], config:{lanes: 2, hspace:1024, fontsize: 16}}
-....
+//[wavedrom, , ]
+//....
+//{reg: [
+//  {bits: 1,  name: 'V',        attr: '1'},
+//  {bits: 9, name: 'reserved', attr: '9'},
+//  {bits: 44, name: 'PPN',      attr: '44'},
+//  {bits: 10,  name: 'reserved', attr: '10'},
+//], config:{lanes: 2, hspace:1024, fontsize: 16}}
+//....
 
 ==== Leaf DDT entry
 The leaf DDT page is indexed by `DDI[0]` and holds the device-context (`DC`).
@@ -219,30 +219,30 @@ The leaf DDT page is indexed by `DDI[0]` and holds the device-context (`DC`).
 In base-format the `DC` is 32-bytes. In extended-format the `DC` is 64-bytes.
 
 .Base-format device-context
-[wavedrom, , ]
-....
-{reg: [
-  {bits: 64,  name: 'Translation-control (tc)'},
-  {bits: 64,  name: 'IO Hypervisor guest address translation and protection (iohgatp)'},
-  {bits: 64,  name: 'Translation-attributes (ta)'},
-  {bits: 64,  name: 'First-stage-context (fsc)'},
-], config:{lanes: 4, hspace: 1024, fontsize: 16}}
-....
+//[wavedrom, , ]
+//....
+//{reg: [
+//  {bits: 64,  name: 'Translation-control (tc)'},
+//  {bits: 64,  name: 'IO Hypervisor guest address translation and protection (iohgatp)'},
+//  {bits: 64,  name: 'Translation-attributes (ta)'},
+//  {bits: 64,  name: 'First-stage-context (fsc)'},
+//], config:{lanes: 4, hspace: 1024, fontsize: 16}}
+//....
 
 .Extended-format device-context
-[wavedrom, , ]
-....
-{reg: [
-  {bits: 64,  name: 'Translation-control (tc)'},
-  {bits: 64,  name: 'IO Hypervisor guest address translation and protection (iohgatp)'},
-  {bits: 64,  name: 'Translation-attributes (ta)'},
-  {bits: 64,  name: 'First-stage-context (fsc)'},
-  {bits: 64,  name: 'MSI-page-table pointer (msiptp)'},
-  {bits: 64,  name: 'MSI-address-mask (msi_addr_mask)'},
-  {bits: 64,  name: 'MSI-address-pattern (msi_addr_pattern)'},
-  {bits: 64,  name: 'reserved'},
-], config:{lanes: 8, hspace: 1024, fontsize: 16}}
-....
+//[wavedrom, , ]
+//....
+//{reg: [
+//  {bits: 64,  name: 'Translation-control (tc)'},
+//  {bits: 64,  name: 'IO Hypervisor guest address translation and protection (iohgatp)'},
+//  {bits: 64,  name: 'Translation-attributes (ta)'},
+//  {bits: 64,  name: 'First-stage-context (fsc)'},
+// {bits: 64,  name: 'MSI-page-table pointer (msiptp)'},
+//  {bits: 64,  name: 'MSI-address-mask (msi_addr_mask)'},
+//  {bits: 64,  name: 'MSI-address-pattern (msi_addr_pattern)'},
+//  {bits: 64,  name: 'reserved'},
+//], config:{lanes: 8, hspace: 1024, fontsize: 16}}
+//....
 
 The `DC` is interpreted as four 64-bit doublewords in base-format and as eight
 64-bit doublewords in extended-format.  The byte order of each of the

--- a/iommu_in_memory_queues.adoc
+++ b/iommu_in_memory_queues.adoc
@@ -270,6 +270,11 @@ match the `GSCID` argument, regardless of the address argument.
 Simpler implementations may ignore the operand of `IOTINVAL.VMA` and/or
 `IOTINVAL.GVMA` and always perform a global invalidation of all
 address-translation entries.
+
+Some implementations may choose to cache an identity-mapped translation for the
+stage of address translation that is in `Bare` mode. The 'IOTINVAL' commands do
+not apply to such identity-mapped translations, as these identity mappings are
+always correct. As a result, there is no need for explicit invalidation.
 ====
 
 [NOTE]

--- a/iommu_intro.adoc
+++ b/iommu_intro.adoc
@@ -52,8 +52,8 @@ management complexity for DMA. Use of an identical format also allows the same
 page tables to be used simultaneously by both the CPU MMU and the IOMMU.
 
 Although there is no option to disable two-stage address translation, either
-stage may be effectivly disabled by configuring the virtual memory scheme for
-that stage to be `Bare` i.e. perfom no address translation or memory protection.
+stage may be effectively disabled by configuring the virtual memory scheme for
+that stage to be `Bare` i.e. perform no address translation or memory protection.
 
 The virtual memory scheme employed by the IOMMU may be configured individually
 per device in the IOMMU. Devices perform DMA using an I/O virtual address (IOVA).
@@ -87,7 +87,7 @@ is a VA. Two-stage address translation is in effect. The first-stage translates
 the VA to a GPA and the second-stage translates the GPA to a SPA. Each stage
 enforces the configured memory protections. Such a configuration would be
 typically be employed when the device control is passed-through to a virtual
-machine and the Guest OS in the VM uses the first-stage addresss translation to
+machine and the Guest OS in the VM uses the first-stage address translation to
 further constrain the memory accessed by such devices and associated privileges
 and memory protections. Comparing to a RISC-V hart, this configuration is
 analogous to two-stage address translation being in effect on a RISC-V hart with
@@ -190,10 +190,6 @@ in the device context.
                     address space of a process. The PASID value is provided in
                     the PASID TLP prefix of the request.
 | PBMT            | Page-Based Memory Types.
-| PPN             | Physical Page Number.
-| PRI             | Page Request Interface - a PCIe protocol that enables
-                    devices to request OS memory manager services to make pages
-                    resident cite:[PCI].
 | PC              | Process Context.
 | PCIe            | Peripheral Component Interconnect Express bus standard
                     cite:[PCI].

--- a/iommu_registers.adoc
+++ b/iommu_registers.adoc
@@ -392,18 +392,19 @@ subset of directory-table levels and device-context widths. At a minimum one
 of the modes must be supported.
 
 When the `iommu_mode` field value is changed to `Off` the IOMMU guarantees that
-in-flight transactions from devices connected to the IOMMU will be processed
-with the configurations applicable to the old value of the `iommu_mode` field
-and that all transactions and previous requests from devices that have already
-been processed by the IOMMU be committed to a global ordering point such that
-they can be observed by all RISC-V harts, devices, and IOMMUs in the platform.
+in-flight transactions, when the write was observed by the IOMMU, from devices
+connected to the IOMMU will be processed with the configurations applicable to
+the old value of the `iommu_mode` field and ensures that all transactions and
+previous requests from devices that have already been processed by the IOMMU be
+committed to a global ordering point such that they can be observed by all
+RISC-V harts, devices, and IOMMUs in the platform.
 
 The IOMMU behavior of writing `iommu_mode` to `1LVL`, `2LVL`, or `3LVL`, when
 the previous value of the `iommu_mode` is not `Off` or `Bare` is `UNSPECIFIED`.
 To change DDT levels, the IOMMU must first be transitioned to `Bare` or `Off`
 state.
 
-When an IOMMU is transitioned to `Bare` of `Off` state, the IOMMU may retain
+When an IOMMU is transitioned to `Bare` or `Off` state, the IOMMU may retain
 information cached from in-memory data structures such as page tables, DDT,
 PDT, etc. Software must use suitable invalidation commands to invalidate cached
 entries.
@@ -779,11 +780,12 @@ status of the command-queue.
                             generation of interrupts from command-queue when
                             set to 1.
 |7:2  |reserved|WPRI    | Reserved for standard use
-|8    |`cqmf`  |RW1C      | If command-queue access leads to a memory fault then
-                            the command-queue-memory-fault bit is set to 1 and
-                            the command-queue stalls until this bit is cleared.
-                            To re-enable command processing, software should
-                            clear this bit by writing 1.
+|8    |`cqmf`  |RW1C      | If command-queue access to fetch a command or a
+                            memory access made by a command leads to a memory
+                            fault, then the command-queue-memory-fault bit is set
+                            to 1, and the command-queue stalls until this bit is
+                            cleared. To re-enable command processing, software
+                            should clear this bit by writing 1.
 |9    |`cmd_to`|RW1C      | If the execution of a command leads to a
                             timeout (e.g. a command to invalidate device ATC
                             may timeout waiting for a completion), then the
@@ -1117,7 +1119,7 @@ interrupt-pending bit.
 |===
 
 If a bit in `ipsr` is 1 then a write of 1 to the bit transitions the bit from 1->0.
-If the conditions to set that bit are still present (See <<IPSR_FIELDS>>) or if
+If the conditions to set that bit are still present (See <<IPSR_FIELD>>) or if
 they occur after the bit is cleared then that bit transitions again from 0->1.
 
 [[OVF]]

--- a/iommu_sw_guidelines.adoc
+++ b/iommu_sw_guidelines.adoc
@@ -138,21 +138,24 @@ previous read and/or write requests, that have already been processed by the
 IOMMU, be committed to a global ordering point as part of the `IOFENCE.C`
 command.
 
+In subsequent sections, when an algorithm step tests values in the in-memory
+data structures to determine the type of invalidation operation to perform, the
+data values tested are the old values i.e. values before a change is made.
+
 [[DC_CHANGE]]
 ==== Changing device directory table entry
 If software changes a leaf-level DDT entry (i.e, a device context (`DC`), of
 device with `device_id = D`) then the following invalidations must be performed:
 
 * `IODIR.INVAL_DDT` with `DV=1` and `DID=D`
-* If `DC.tc.PDTV==1` then `IODIR.INVAL_PDT` with `DV=1`, `PV=0`, and `DID=D`
 
 * If `DC.iohgatp.MODE != Bare`
 ** `IOTINVAL.VMA` with `GV=1`, `AV=PSCV=0`, and `GSCID=DC.iohgatp.GSCID`
 ** `IOTINVAL.GVMA` with `GV=1`, `AV=0`, and `GSCID=DC.iohgatp.GSCID`
 * else
-** If `DC.tc.PDTV==1 || DC.tc.PDTV == 0 && DC.fsc.MODE == Bare`
+** If `DC.tc.PDTV==1`
 *** `IOTINVAL.VMA` with `GV=AV=PSCV=0`
-** else
+** else if `DC.fsc.MODE != Bare`
 *** `IOTINVAL.VMA` with `GV=AV=0` and `PSCV=1`, and `PSCID=DC.ta.PSCID`
 
 If software changes a non-leaf-level DDT entry the following invalidations
@@ -170,12 +173,17 @@ If software changes a leaf-level PDT entry (i.e, a process context (`PC`), for
 `device_id=D` and `process_id=P`) then the following invalidations must be
 performed:
 
-* `IODIR.INVAL_PDT` with `DV=1`, `PV=1`, `DID=D` and `PID=P`
+* `IODIR.INVAL_PDT` with `DV=1`, `DID=D` and `PID=P`
 * If `DC.iohgatp.MODE != Bare`
 ** `IOTINVAL.VMA` with `GV=1`, `AV=0`, `PV=1`, `GSCID=DC.iohgatp.GSCID`,
    and `PSCID=PC.PSCID`
 * else
 ** `IOTINVAL.VMA` with `GV=0`, `AV=0`, `PV=1`, and `PSCID=PC.PSCID`
+
+If software changes a non-leaf-level PDT entry the following invalidations
+must be performed:
+
+* `IODIR.INVAL_DDT` with `DV=1` and `DID=D`
 
 Between a change to the PDT entry and when an invalidation command to invalidate
 the cached entry is processed by the IOMMU, the IOMMU may use the old value or


### PR DESCRIPTION
* Fix mispelt words
* PV operand was dropped from INVAL_PDT
* Remove duplicate PRI and PPN entry
* Typo:of->or
* Typo: IPSR_FIELDS -> IPSR_FIELD
* Update toclevels to 5 for PDF rendering
* Clarify Bare translations, if created, dont need explicit invalidations
* Clarify that cqmf is also set for memory access by command itself
* Clarify that values tests by the algorithm are values before the change
* Add missing guideline for non-leaf PDT change
* Clarify previous transactions are from before ddtp write