### PR TITLE
GIPC: Introduce G-stage page table In Process Context (GIPC) capability

### DIFF
--- a/iommu_ref_model/libiommu/include/iommu_data_structures.h
+++ b/iommu_ref_model/libiommu/include/iommu_data_structures.h
@@ -101,7 +101,12 @@ typedef union {
         //   to the original access type occurs if the incoming GPA has bits set beyond bit 33.
         uint64_t SXL:1;
 
-        uint64_t reserved0:12;
+        // The GIPC field controls using 32-bytes extended process context for PDT leaf entry.
+        // If DC.tc.GIPC is 1 then the process context uses PC.iohgatp instead of DC.iohgatp.
+        // Every Process Context has its own G-stage Table: G-stage table In Process Context (GIPC)
+        uint64_t GIPC:1;
+
+        uint64_t reserved0:11;
         uint64_t custom:8;
         uint64_t reserved1:32;
     };
@@ -386,6 +391,8 @@ typedef union {
 typedef struct {
     pc_ta_t  ta;
     pc_fsc_t fsc;
+    iohgatp_t iohgatp;
+    uint64_t  reserved;
 } process_context_t;
 
 #endif // __IOMMU_DATA_STRUCTURES_H__

--- a/iommu_ref_model/libiommu/include/iommu_registers.h
+++ b/iommu_ref_model/libiommu/include/iommu_registers.h
@@ -78,7 +78,8 @@ typedef union {
         uint64_t qosid   : 1;      // Associating QoS IDs with requests is supported.
         uint64_t nl      : 1;      // Non-leaf PTE invalidation extension is supported.
         uint64_t s       : 1;      // Address range invalidation extension is supported.
-        uint64_t rsvd3   : 12;     // Reserved for standard use
+        uint64_t GIPC    : 1;      // G-stage table In Process Context is supported.
+        uint64_t rsvd3   : 11;     // Reserved for standard use
         uint64_t custom  : 8;      // _Designated for custom use_
     };
     uint64_t raw;

--- a/iommu_ref_model/test/test_app.h
+++ b/iommu_ref_model/test/test_app.h
@@ -27,7 +27,7 @@ extern int8_t check_exp_pq_rec(uint32_t DID, uint32_t PID, uint8_t PV, uint8_t P
 extern uint64_t get_free_gppn(uint64_t num_gppn, iohgatp_t iohgatp);
 extern uint64_t add_device(uint32_t device_id, uint32_t gscid, uint8_t en_ats, uint8_t en_pri, uint8_t t2gpa,
            uint8_t dtf, uint8_t prpr,
-           uint8_t gade, uint8_t sade, uint8_t dpe, uint8_t sbe, uint8_t sxl,
+           uint8_t gade, uint8_t sade, uint8_t dpe, uint8_t sbe, uint8_t sxl, uint8_t gipc,
            uint8_t iohgatp_mode, uint8_t iosatp_mode, uint8_t pdt_mode,
            uint8_t msiptp_mode, uint8_t msiptp_pages, uint64_t msi_addr_mask,
            uint64_t msi_addr_pattern);

--- a/iommu_ref_model/test/test_utils.c
+++ b/iommu_ref_model/test/test_utils.c
@@ -296,7 +296,7 @@ check_rsp_and_faults(
 uint64_t
 add_device(uint32_t device_id, uint32_t gscid, uint8_t en_ats, uint8_t en_pri, uint8_t t2gpa,
            uint8_t dtf, uint8_t prpr,
-           uint8_t gade, uint8_t sade, uint8_t dpe, uint8_t sbe, uint8_t sxl,
+           uint8_t gade, uint8_t sade, uint8_t dpe, uint8_t sbe, uint8_t sxl, uint8_t gipc,
            uint8_t iohgatp_mode, uint8_t iosatp_mode, uint8_t pdt_mode,
            uint8_t msiptp_mode, uint8_t msiptp_pages, uint64_t msi_addr_mask,
            uint64_t msi_addr_pattern) {
@@ -316,6 +316,7 @@ add_device(uint32_t device_id, uint32_t gscid, uint8_t en_ats, uint8_t en_pri, u
     DC.tc.DPE    = dpe;
     DC.tc.SBE    = sbe;
     DC.tc.SXL    = sxl;
+    DC.tc.GIPC   = gipc;
     if ( iohgatp_mode != IOHGATP_Bare ) {
         DC.iohgatp.GSCID = gscid;
         DC.iohgatp.PPN = get_free_ppn(4);
@@ -349,7 +350,7 @@ add_device(uint32_t device_id, uint32_t gscid, uint8_t en_ats, uint8_t en_pri, u
     if ( pdt_mode != PDTP_Bare ) {
         DC.tc.PDTV = 1;
         DC.fsc.pdtp.MODE = pdt_mode;
-        if ( DC.iohgatp.MODE != IOHGATP_Bare ) {
+        if ((DC.iohgatp.MODE != IOHGATP_Bare) && !((DC.tc.GIPC == 1) && (g_reg_file.capabilities.GIPC == 1))) {
             gpte_t gpte;
             DC.fsc.pdtp.PPN = get_free_gppn(1, DC.iohgatp);
             gpte.raw = 0;

--- a/src/iommu_data_structures.adoc
+++ b/src/iommu_data_structures.adoc
@@ -19,7 +19,7 @@ then only the first-stage suffices to perform necessary address translations and
 protections; the second-stage scheme may be effectively disabled for the device by
 programming the second-stage address translation scheme to be `Bare`.
 
-When second-stage address translation is not Bare, the `DC` holds the PPN of the
+When second-stage address translation is not Bare, the `iohgatp` holds the PPN of the
 root second-stage page table; a guest-soft-context-ID (`GSCID`), which
 facilitates invalidation of cached address translations on a per-virtual-machine
 basis; and the second-stage address translation scheme.
@@ -39,6 +39,9 @@ a data structure called the Process Context (`PC`).
 
 When a PDT is active, the controls for first-stage address translation are held
 in the (`PC`).
+
+When a PDT is active with GIPC enabled, the controls for first-stage
+and second-stage address translation are held in the (`PC`).
 
 When a PDT is not active, the controls for first-stage address translation are
 held in the `DC` itself.
@@ -109,7 +112,7 @@ maximum width of the `process_id` supported by that device.  The partitioning
 of the `process_id` to obtain the process directory indices (PDI) to traverse
 the PDT radix-tree are as follows:
 
-.`process_id` partitioning for PDT radix-tree traversal
+.Base format `process_id` partitioning for PDT radix-tree traversal
 
 [wavedrom, , ]
 ....
@@ -119,6 +122,18 @@ the PDT radix-tree are as follows:
   {bits: 3, name: 'PDI[2]'},
 ], config:{lanes: 1, hspace:1024, fontsize: 16}}
 ....
+
+.Extended format `process_id` partitioning for PDT radix-tree traversal when `DC.tc.GIPC=1`
+
+[wavedrom, , ]
+....
+{reg: [
+  {bits: 7, name: 'PDI[0]'},
+  {bits: 9, name: 'PDI[1]'},
+  {bits: 4, name: 'PDI[2]'},
+], config:{lanes: 1, hspace:1024, fontsize: 16}}
+....
+
 [NOTE]
 ====
 The `process_id` partitioning is designed to require a maximum of 4 KiB, a
@@ -273,7 +288,8 @@ order.
   {bits: 1,  name: 'DPE'},
   {bits: 1,  name: 'SBE'},
   {bits: 1,  name: 'SXL'},
-  {bits: 12, name: 'reserved'},
+  {bits: 1,  name: 'GIPC'},
+  {bits: 11, name: 'reserved'},
   {bits: 8, name: 'custom'},
   {bits: 32, name: 'reserved'},
 ], config:{lanes: 4, hspace: 1024, fontsize: 16, fontsize: 16}}
@@ -387,6 +403,9 @@ When `PDTV` is 1, the `DPE` bit may set to 1 to enable the use of 0 as the
 default value of `process_id` for translating requests without a valid
 `process_id`. When `PDTV` is 0, the `DPE` bit is reserved for future standard
 extension.
+
+The `GIPC` bit is expected to be set to 1 when `PC` is associated with iohgatp.
+The `DC.tc.GIPC` depends on `capabilities.GIPC`.
 
 The IOMMU supports the 1 setting of `GADE` and `SADE` bits if
 `capabilities.AMO_HWAD` is 1. When `capabilities.AMO_HWAD` is 0, these bits are
@@ -599,13 +618,19 @@ determines the number of levels of the PDT.
 ], config:{lanes: 2, hspace: 1024, fontsize: 16}}
 ....
 
-When second-stage address translation is not Bare, the `pdtp.PPN` field holds a
+When second-stage address translation is not Bare and GIPC is disabled, the `pdtp.PPN` field holds a
 guest PPN. The GPA of the root PDT is then converted by guest physical address
 translation process, as controlled by the `iohgatp`, into a supervisor physical
 address. Translating addresses of PDT using a second-stage page table, allows the
 PDT to be held in memory allocated by the guest OS and allows the guest OS to
 directly edit the PDT to associate a virtual-address space identified by a
 first-stage page table with a `process_id`.
+
+When `GIPC` is enabled, the `pdtp.PPN` field holds a supervisor PPN. The supervisor physical
+address of PDT root page, allows the PDT to be configured into the supervisor physical
+address space to allow the guest OS to use vIOMMU API edit the PDT in hypervisor to
+associate a virtual-address space identified by a VS-stage page table with a
+`process_id`.
 
 [[PDTP_MODE_ENC]]
 .Encodings of `pdtp.MODE` field
@@ -614,14 +639,28 @@ first-stage page table with a `process_id`.
 |===
 ^|Value ^| Name     ^| Description
 | 0    | `Bare`   | No first-stage address translation or protection.
-| 1    | `PD8`    | 8-bit process ID enabled. The directory has 1 levels with
-                    256 entries.The bits 19:8 of `process_id` must be 0.
-| 2    | `PD17`   | 17-bit process ID enabled. The directory has 2 levels.
-                    The root PDT page has 512 entries and leaf level has
-                    256 entries. The bits 19:17 of `process_id` must be 0.
-| 3    | `PD20`   | 20-bit process ID enabled. The directory has 3 levels.
-                    The root PDT has 8 entries and the next non-leaf
-                    level has 512 entries. The leaf level has 256 entries.
+| 1    | `PD8`    | 8-bit process ID enabled when `GIPC` is disabled. The
+                    directory has 1 levels with 256 entries. The bits 19:8
+                    of `process_id` must be 0.
+                    7-bit process ID enabled when `GIPC` is enabled. The
+                    directory has 1 levels with 128 entries. The bits 19:7
+                    of `process_id` must be 0.
+| 2    | `PD17`   | 17-bit process ID enabled when `GIPC` is disabled. The
+                    directory has 2 levels. The root PDT page has 512
+                    entries and leaf level has 256 entries. The bits 19:17
+                    of `process_id` must be 0.
+                    16-bit process ID enabled when `GIPC` is enabled. The
+                    directory has 2 levels. The root PDT page has 512
+                    entries and leaf level has 128 entries. The bits 19:16
+                    of `process_id` must be 0.
+| 3    | `PD20`   | 20-bit process ID enabled when `GIPC` is disabled. The
+                    directory has 3 levels. The root PDT has 8 entries and
+                    the next non-leaf level has 512 entries. The leaf level
+                    has 256 entries.
+                    20-bit process ID enabled when `GIPC` is enabled. The
+                    directory has 3 levels. The root PDT has 16 entries and
+                    the next non-leaf level has 512 entries. The leaf level
+                    has 128 entries.
 |  4-13| --       | Reserved for standard use.
 | 14-15| --       | Designated for custom use.
 |===
@@ -829,9 +868,9 @@ A valid (`V==1`) non-leaf PDT entry holds the PPN of the next-level PDT.
 
 ==== Leaf PDT entry
 The leaf PDT page is indexed by `PDI[0]` and holds the 16-byte process-context
-(`PC`).
+(`PC`) when `DC.tc.GIPC = 0`.
 
-.Process-context
+.Base-format process-context
 
 [wavedrom, , ]
 ....
@@ -841,7 +880,22 @@ The leaf PDT page is indexed by `PDI[0]` and holds the 16-byte process-context
 ], config:{lanes: 2, hspace: 1024, fontsize: 16}}
 ....
 
-The `PC` is interpreted as two 64-bit doublewords. The byte order of each of the
+The leaf PDT page is indexed by `PDI[0]` and holds the 32-byte process-context
+(`PC`) when `DC.tc.GIPC = 1`.
+
+.Extended-format process-context
+
+[wavedrom, , ]
+....
+{reg: [
+  {bits: 64,  name: 'reserved'},
+  {bits: 64,  name: 'IO Hypervisor guest address translation and protection (iohgatp)'},
+  {bits: 64,  name: 'Translation-attributes (ta)'},
+  {bits: 64,  name: 'First-stage-context (fsc)'},
+], config:{lanes: 2, hspace: 1024, fontsize: 16}}
+....
+
+The `PC` is interpreted as multi 64-bit doublewords. The byte order of each of the
 doublewords in memory, little-endian or big-endian, is the endianness as
 determined by `DC.tc.SBE`. The IOMMU may read the `PC` fields in any order.
 
@@ -906,7 +960,7 @@ holds the PPN of the root page of a first-stage page table.
 When second-stage address translation is not Bare, the `PC.fsc.PPN` field holds
 a guest PPN of the root of a first-stage page table. Addresses of the first-stage
 page table entries are then converted by guest physical address translation
-process, as controlled by the `DC.iohgatp`, into a supervisor physical address.
+process, as controlled by the `iohgatp`, into a supervisor physical address.
 A guest OS may thus directly edit the first-stage page table to limit access by
 the device to a subset of its memory and specify permissions for the device
 accesses.
@@ -919,6 +973,9 @@ are not identical then it is unpredictable whether the IOMMU uses the PTEs from
 the first page table or the second page table. These are the only expected
 behaviors.
 ====
+
+===== IO hypervisor guest address translation and protection (`iohgatp`)
+The same as `DC.iohgatp`.
 
 [[PC_MISCONFIG]]
 ==== Process-context configuration checks
@@ -1001,7 +1058,8 @@ The process to translate an `IOVA` is as follows:
 .. Let `A` be the `IOVA` (the `IOVA` is a GPA).
 .. Let `iosatp.MODE` be `Bare`
 ... The `PSCID` value is not used when first-stage is Bare.
-.. Let `iohgatp` be the value in the `DC.iohgatp` field
+.. Let `iohgatp` be the value in the `DC.iohgatp` field if `DC.tc.GIPC` is 0.
+.. Let `iohgatp` be the value in the `PC.iohgatp` field if `DC.tc.GIPC` is actived.
 . If `DC.tc.PDTV` is set to 0 then go to step 17 with the following page table
   information:
 .. Let `iosatp.MODE` be the value in the `DC.fsc.MODE` field
@@ -1028,7 +1086,8 @@ The process to translate an `IOVA` is as follows:
 .. Let `iosatp.MODE` be the value in the `PC.fsc.MODE` field
 .. Let `iosatp.PPN` be the value in the `PC.fsc.PPN` field
 .. Let `PSCID` be the value in the `PC.ta.PSCID` field
-.. Let `iohgatp` be the value in the `DC.iohgatp` field
+.. Let `iohgatp` be the value in the `DC.iohgatp` field if `DC.tc.GIPC` is 0.
+.. Let `iohgatp` be the value in the `PC.iohgatp` field if `DC.tc.GIPC` is actived.
 . Use the process specified in Section "Two-Stage Address Translation" of the
   RISC-V Privileged specification cite:[PRIV] to determine the GPA accessed by
   the transaction. If a fault is detected by the first stage address translation
@@ -1098,9 +1157,9 @@ is as follows:
 ==== Process to locate the Process-context
 
 The device-context provides the PDT root page PPN (`pdtp.ppn`).  When
-`DC.iohgatp.mode` is not `Bare`, `pdtp.PPN` as well as `pdte.PPN` are Guest
+`iohgatp.mode` is not `Bare` and `DC.tc.GIPC` is 0, `pdtp.PPN` as well as `pdte.PPN` are Guest
 Physical Addresses (GPA) which must be translated into Supervisor Physical
-Addresses (SPA) using the second-stage page table pointed to by `DC.iohgatp`.
+Addresses (SPA) using the second-stage page table pointed to by `iohgatp`.
 The memory accesses to the PDT are treated as implicit read memory accesses
 by the second-stage. However, any guest-page fault exception raised by the
 second stage is always reported using the original access type (instruction,
@@ -1109,17 +1168,21 @@ entry load access fault" (`cause = 265`). If the second-stage accesses detect
 data corruption (i.e., poisoned data), it is reported as "PDT data corruption"
 (`cause = 269`).
 
+When `iohgatp.mode` is not `Bare` and `DC.tc.GIPC` is actived, `pdtp.PPN` as well
+as `pdte.PPN` are Supervisor Physical Addresses (SPA).
+
 The process to locate the Process-context for a transaction using its
 `process_id` is as follows:
 
 . Let `a` be `pdtp.PPN x 2^12^` and let `i = LEVELS - 1`. When
   `pdtp.MODE` is `PD20`, `LEVELS` is three. When `pdtp.MODE` is
   `PD17`, `LEVELS` is two. When `pdtp.MODE` is `PD8`, `LEVELS` is one.
-. If `DC.iohgatp.mode != Bare`, then `a` is a GPA. Invoke the process
+. If `iohgatp.mode != Bare` and `DC.tc.GIPC` is 0, then `a` is a GPA. Invoke the process
   to translate `a` to a SPA as an implicit memory access. If faults occur during
   second-stage address translation of `a` then stop and report the fault detected
   by the second-stage address translation process. The translated `a` is used in
   subsequent steps.
+. If `iohgatp.mode == Bare` or `DC.tc.GIPC` is actived, then `a` is a SPA.
 . If `i == 0` go to step 9.
 . Let `pdte` be the value of the eight bytes at address `a + PDI[i] x 8`. If
   accessing `pdte` violates a PMA or PMP check, then stop and report
@@ -1130,7 +1193,12 @@ The process to locate the Process-context for a transaction using its
 . If any bits or encoding that are reserved for future standard use are
   set within `pdte`, stop and report "PDT entry misconfigured" (cause = 267).
 . Let `i = i - 1` and let `a = pdte.PPN x 2^12^`. Go to step 2.
-. Let `PC` be the value of the 16-bytes at address `a + PDI[0] x 16`. If accessing `PC`
+. Let `PC` be the value of the 16 bytes at address `a + PDI[0] x 16` when `DC.tc.GIPC` is 0.
+  If accessing `PC` violates a PMA or PMP check, then stop and report "PDT entry load access
+  fault" (cause = 265). If `PC` access detects a data corruption
+  (a.k.a. poisoned data), then stop and report "PDT data corruption"
+  (cause = 269).
+. Let `PC` be the value of the 32 bytes at address `a + PDI[0] x 32` when `DC.tc.GIPC` is actived. If accessing `PC`
   violates a PMA or PMP check, then stop and report "PDT entry load access
   fault" (cause = 265). If `PC` access detects a data corruption
   (a.k.a. poisoned data), then stop and report "PDT data corruption"

--- a/src/iommu_intro.adoc
+++ b/src/iommu_intro.adoc
@@ -103,7 +103,7 @@ accesses. The IOMMU may employ similar address translation caches, referred as
 IOMMU Address Translation Cache (IOATC). The IOMMU provides mechanisms for
 software to synchronize the IOATC with the memory resident data structures used
 for address translation when they are modified. Software may configure the
-device context with a software defined context identifier called guest
+iohgatp with a software defined context identifier called guest
 soft-context identifier (`GSCID`) to indicate that a collection of devices are
 assigned to the same VM and thus access a common virtual address space.
 Software may configure the process context with a software defined context
@@ -170,6 +170,7 @@ in the device context.
 | DMA             | Direct Memory Access.
 | GPA             | Guest Physical Address: An address in the virtualized
                     physical memory space of a virtual machine.
+| GIPC            | G-stage page table In Process Context.
 | GSCID           | Guest soft-context identifier: An identification number used
                     by software to uniquely identify a collection of devices
                     assigned to a virtual machine. An IOMMU may tag IOATC

--- a/src/iommu_registers.adoc
+++ b/src/iommu_registers.adoc
@@ -158,7 +158,8 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
   {bits: 1, name: 'QOSID'},
   {bits: 1, name: 'NL'},
   {bits: 1, name: 'S'},
-  {bits: 12, name: 'reserved'},
+  {bits: 1, name: 'GIPC'},
+  {bits: 11, name: 'reserved'},
   {bits: 8, name: 'custom'},
 ], config:{lanes: 8, hspace:1024}}
 ....
@@ -232,7 +233,8 @@ the IOMMU. At reset, the register shall contain the IOMMU supported features.
 |41    |`QOSID`    |RO        | Associating QoS IDs with requests is supported.
 |42    |`NL`       |RO        | Non-leaf PTE invalidation extension is supported.
 |43    |`S`        |RO        | Address range invalidation extension is supported.
-|55:44 | reserved  |RO        | Reserved for standard use.
+|44    |`GIPC`     |RO        | G-stage page table In Process Context supported.
+|55:45 | reserved  |RO        | Reserved for standard use.
 |63:56 |custom     |RO        | Designated for custom use.
 |===
 

--- a/src/iommu_sw_guidelines.adoc
+++ b/src/iommu_sw_guidelines.adoc
@@ -146,9 +146,9 @@ device with `device_id = D`) then the following invalidations must be performed:
 
 * `IODIR.INVAL_DDT` with `DV=1` and `DID=D`
 
-* If `DC.iohgatp.MODE != Bare`
-** `IOTINVAL.VMA` with `GV=1`, `AV=PSCV=0`, and `GSCID=DC.iohgatp.GSCID`
-** `IOTINVAL.GVMA` with `GV=1`, `AV=0`, and `GSCID=DC.iohgatp.GSCID`
+* If `iohgatp.MODE != Bare`
+** `IOTINVAL.VMA` with `GV=1`, `AV=PSCV=0`, and `GSCID=iohgatp.GSCID`
+** `IOTINVAL.GVMA` with `GV=1`, `AV=0`, and `GSCID=iohgatp.GSCID`
 * else
 ** If `DC.tc.PDTV==1`
 *** `IOTINVAL.VMA` with `GV=AV=PSCV=0`
@@ -171,8 +171,8 @@ If software changes a leaf-level PDT entry (i.e, a process context (`PC`), for
 performed:
 
 * `IODIR.INVAL_PDT` with `DV=1`, `DID=D` and `PID=P`
-* If `DC.iohgatp.MODE != Bare`
-** `IOTINVAL.VMA` with `GV=1`, `AV=0`, `PSCV=1`, `GSCID=DC.iohgatp.GSCID`,
+* If `iohgatp.MODE != Bare`
+** `IOTINVAL.VMA` with `GV=1`, `AV=0`, `PSCV=1`, `GSCID=iohgatp.GSCID`,
    and `PSCID=PC.PSCID`
 * else
 ** `IOTINVAL.VMA` with `GV=0`, `AV=0`, `PSCV=1`, and `PSCID=PC.PSCID`
@@ -193,12 +193,12 @@ number `I` that corresponds to an untranslated MSI address `A` then the followin
 invalidations must be performed:
 
 * `IOTINVAL.GVMA` with `GV=AV=1`, `ADDR[63:12]=A[63:12]` and
-    `GSCID=DC.iohgatp.GSCID`
+    `GSCID=iohgatp.GSCID`
 
 To invalidate all cache entries from a MSI page table the following
 invalidations must be performed:
 
-* `IOTINVAL.GVMA` with `GV=1`, `AV=0`, and `GSCID=DC.iohgatp.GSCID`
+* `IOTINVAL.GVMA` with `GV=1`, `AV=0`, and `GSCID=iohgatp.GSCID`
 
 Between a change to the MSI PTE and when an invalidation command to invalidate
 the cached PTE is processed by the IOMMU, the IOMMU may use the old PTE value
@@ -212,12 +212,12 @@ If software changes a leaf second-stage page-table entry of a VM where the chang
 affects translation for a guest-PPN `G` then the following invalidations must be
 performed:
 
-* `IOTINVAL.GVMA` with `GV=AV=1`, `GSCID=DC.iohgatp.GSCID`, and `ADDR[63:12]=G`
+* `IOTINVAL.GVMA` with `GV=AV=1`, `GSCID=iohgatp.GSCID`, and `ADDR[63:12]=G`
 
 If software changes a non-leaf second-stage page-table entry of a VM
 then the following invalidations must be performed:
 
-* `IOTINVAL.GVMA` with `GV=1`, `AV=0`, `GSCID=DC.iohgatp.GSCID`
+* `IOTINVAL.GVMA` with `GV=1`, `AV=0`, `GSCID=iohgatp.GSCID`
 
 The `DC` has fields that hold a guest-PPN. An implementation may translate such
 fields to a supervisor-PPN as part of caching the `DC`. If the second-stage page
@@ -243,7 +243,7 @@ specified in <<IVMA>>.
 
 When a change is made to a first-stage page table, and the second-stage is
 not Bare, then software must perform invalidations using `IOTINVAL.VMA` with
-`GV=1`, `GSCID=DC.iohgatp.GSCID` and `AV` and `PSCV` operands appropriate for
+`GV=1`, `GSCID=iohgatp.GSCID` and `AV` and `PSCV` operands appropriate for
 the modification as specified in <<IVMA>>.
 
 Between a change to the first-stage PTE and when an invalidation command to


### PR DESCRIPTION
The current G-stage page table of RISC-V IOMMU resides within the device context and is only bound to one DC (G-stage table In Device Context - GIDC). Consequently, this limits the DSWQ (Device Shared Work Queue) to serve only one virtual machine. The DSWQ uses process_id to distinguish the different address spaces.

So, adding iohgatp into Process Context could make DSWQ serve different virtual machines. The GIPC (G-stage table In Process Context) capability adds iohgatp in PC (Process Context), and makes RISC-V IOMMU support GIPC and GIDC simultaneously. This improves the virtualization scalability of heterogeneous programming in DSWQ scenarios.

Here is the abstract of this approach:
   - Add capability.GIPC.
   - Add DC.tc.GIPC to enable/disable GIPC for per Device.
   - Add new Extended-format Process Context with iohgatp field (32-bytes).
   - Use SPA instead of GPA for DC.fsc.pdtp when DC.tc.GIPC = 1.
     (The hypervisor maintains the PDT instead of the guest OS.)
 
Qemu GIPC implementation & PDT Nested fixup:
https://github.com/XUANTIE-RV/qemu/pull/11

Open source IOMMU GIPC reference:
https://github.com/zero-day-labs/riscv-iommu/pull/43
    
 Add GIPC ref_model support:
======================= 
    Add Test 25 : G-stage table In Process Context (GIPC):
    
    Running IOMMU test suite
    Test 01 : All inbound transactions disallowed      : PASS
    Test 02 : Bare mode tests                          : PASS
    Test 03 : Too wide device_id                       : PASS
    Test 04 : Non-leaf DDTE invalid                    : PASS
    Test 05 : NL-DDT access viol & data corruption     : PASS
    Test 06 : Non-leaf DDTE reserved bits              : PASS
    Test 07 : Fault queue overflow and memory fault    : PASS
    Test 08 : Device context invalid                   : PASS
    Test 09 : Device context misconfigured             : PASS
    Test 10 : Unsupported transaction type             : PASS
    Test 11 : Dev. ctx. access viol & data corruption  : PASS
    Test 12 : Device context invalidation              : PASS
    Test 13 : IOFENCE                                  : PASS
    Test 14 : G-stage translation sizes                : PASS
    Test 15 : G-stage permission faults                : PASS
    Test 16 : IOTINVAL.GVMA                            : PASS
    Test 17 : S-stage translation sizes                : PASS
    Test 18 : S-stage permission faults                : PASS
    Test 19 : IOTINVAL.VMA                             : PASS
    Test 20 : HPM filtering                            : PASS
    Test 21 : Process Directory Table walk             : PASS
    Test 22 : ATS page request group response          : PASS
    Test 23 : ATS page request                         : PASS
    Test 24 : ATS inval request                        : PASS
    Test 25 : G-stage table In Process Context (GIPC)  : PASS
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    Test 26 : MSI write-through mode                   : PASS
    Test 27 : MSI MFIF mode                            : PASS
    Test 28 : Illegal commands and CQ mem faults       : PASS
    Test 29 : Sv32 mode                                : PASS
    Test 30 : Misc. Register Access tests              : PASS

    ------------------------------------------------------------------------------
                               GCC Code Coverage Report
    Directory: .
    ------------------------------------------------------------------------------
    File                                       Lines    Exec  Cover   Missing
    ------------------------------------------------------------------------------
    src/iommu_atc.c                              127     127   100%
    src/iommu_ats.c                              163     163   100%
    src/iommu_command_queue.c                    215     215   100%
    src/iommu_device_context.c                   148     148   100%
    src/iommu_faults.c                            41      41   100%
    src/iommu_hpm.c                               31      31   100%
    src/iommu_interrupt.c                         55      55   100%
    src/iommu_msi_trans.c                         75      75   100%
    src/iommu_process_context.c                   97      97   100%
    src/iommu_reg.c                              399     399   100%
    src/iommu_second_stage_trans.c               136     136   100%
    src/iommu_translate.c                        231     231   100%
    src/iommu_two_stage_trans.c                  174     174   100%
    src/iommu_utils.c                              5       5   100%
    ------------------------------------------------------------------------------
    TOTAL                                       1897    1897   100%
    ------------------------------------------------------------------------------
    lines: 100.0% (1897 out of 1897)
    branches: 84.3% (1499 out of 1779)

    
    