### PR TITLE
fix images

### DIFF
--- a/src/riscv-iommu.adoc
+++ b/src/riscv-iommu.adoc
@@ -8,8 +8,7 @@ include::../docs-resources/global-config.adoc[]
 :preface-title: Preamble
 :colophon:
 :appendix-caption: Appendix
-:imagesdir: ../docs-resources/images
-:title-logo-image: image:risc-v_logo.png["RISC-V International Logo",pdfwidth=3.25in,align=center]
+:title-logo-image: image:../docs-resources/images/risc-v_logo.png["RISC-V International Logo",pdfwidth=3.25in,align=center]
 // Settings:
 :experimental:
 :reproducible:
@@ -67,7 +66,6 @@ Copyright 2023 by RISC-V International.
 include::contributors.adoc[]
 // Preamble - End
 
-:imagesdir: images
 include::iommu_preface.adoc[]
 include::iommu_intro.adoc[]
 include::iommu_data_structures.adoc[]


### PR DESCRIPTION
The git preview fix added images/ prefix to image file references, but didn't take into account that the prefix is already added by :imagesdir: when building the document, resulting in invalid images/images/ paths.

Remove :imagesdir: to have images in both the build and the git preview.

Fixes: 81916d30439c ("fix image location.") (https://github.com/riscv-non-isa/riscv-iommu/pull/501)