### PR TITLE
Initialize Exe bit to 0 in tr_req_ctrl

### DIFF
--- a/iommu_ref_model/test/test_app.c
+++ b/iommu_ref_model/test/test_app.c
@@ -1568,6 +1568,7 @@ main(void) {
     tr_req_ctrl.PV = 0;
     tr_req_ctrl.NW = 1;
     tr_req_ctrl.go_busy = 1;
+    tr_req_ctrl.Exe = 0;
     tr_req_iova.raw = req.tr.iova;
     write_register(TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
     write_register(TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);


### PR DESCRIPTION
Some of the fields on the tr_req_ctrl variable are left uninitialized. If the Exe bit is 1, test 15 fails with the error "Bad fault record". Initializing the bit to 0 fixes this test failure.

Note that there are possibly other instances of fields left uninitialized which should also be fixed. This change does the minimum amount necessary to make the test pass for me.