### PR TITLE
Rename variable declarations to match definitions

### DIFF
--- a/iommu_ref_model/libiommu/include/iommu_ref_api.h
+++ b/iommu_ref_model/libiommu/include/iommu_ref_api.h
@@ -19,7 +19,7 @@ extern void write_register(uint16_t offset, uint8_t num_bytes, uint64_t data);
 
 #define FILL_IOATC_ATS_T2GPA  0x01
 #define FILL_IOATC_ATS_ALWAYS 0x02
-extern int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_mask,
+extern int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_limit,
                        uint8_t num_vec_bits, uint8_t reset_iommu_mode,
                        uint8_t max_iommu_mode, uint32_t max_devid_mask,
                        uint8_t gxl_writeable, uint8_t fctl_be_writeable,

--- a/iommu_ref_model/libiommu/include/iommu_registers.h
+++ b/iommu_ref_model/libiommu/include/iommu_registers.h
@@ -808,11 +808,11 @@ typedef union {                        // |Ofst|Name            |Size|Descriptio
 extern iommu_regs_t g_reg_file;
 extern uint8_t g_num_hpm;
 extern uint8_t g_hpmctr_bits;
-extern uint8_t g_eventID_mask;
+extern uint8_t g_eventID_limit;
 extern uint8_t g_num_vec_bits;
 extern uint8_t g_gxl_writeable;
 extern uint8_t g_fctl_be_writeable;
-extern uint8_t offset_to_size[4096];
+extern uint8_t g_offset_to_size[4096];
 extern uint8_t g_max_iommu_mode;
 extern uint8_t g_fill_ats_trans_in_ioatc;
 extern uint32_t g_max_devid_mask;


### PR DESCRIPTION
A parameter name on the reset_iommu() declaration is also renamed to match its definition