### PR TITLE
Replace global state with struct

### DIFF
--- a/iommu_ref_model/README.md
+++ b/iommu_ref_model/README.md
@@ -93,7 +93,10 @@ group response - to the test bench.
 These functions are provided by the reference model to the test bench to input stimulii and
 obtain responses from the model.
 
-1. **`uint64_t read_register(uint16_t offset, uint8_t num_bytes)`**
+Each function takes as its first parameter a pointer to an `iommu_t` which is a
+struct containing the internal state of the IOMMU.
+
+1. **`uint64_t read_register(iommu_t *iommu, uint16_t offset, uint8_t num_bytes)`**
 
 This function is provided by the reference model to read a memory mapped IOMMU
 register. The register is identified by the offset parameter and the number of bytes
@@ -101,7 +104,7 @@ read is identified by the num_bytes parameter. The register data is returned by 
 function. If the access is invalid then the function returns all 1's i.e. an abort
 response.
 
-2. **`void write_register(uint16_t offset, uint8_t num_bytes, uint64_t data)`**
+2. **`void write_register(iommu_t *iommu, uint16_t offset, uint8_t num_bytes, uint64_t data)`**
 
 This function is provided by the reference model to write a memory mapped IOMMU
 register. The register is identified by the offset parameter and the number of bytes
@@ -109,7 +112,7 @@ written is identified by the num_bytes parameter. The data to be written is prov
 in the data parameter. If the access is invalid then the function drops the write i.e.
 an abort response.
 
-3. **`int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_limit, uint8_t num_vec_bits, uint8_t reset_iommu_mode, uint8_t max_iommu_mode, uint32_t max_devid_mask, uint8_t gxl_writeable, uint8_t fctl_be_writeable, uint8_t fill_ats_trans_in_ioatc, capabilities_t capabilities, fctl_t fctl, uint64_t sv57_bare_pg_sz, uint64_t sv48_bare_pg_sz, uint64_t sv39_bare_pg_sz, uint64_t sv32_bare_pg_sz, uint64_t sv57x4_bare_pg_sz, uint64_t sv48x4_bare_pg_sz, uint64_t sv39x4_bare_pg_sz, uint64_t sv32x4_bare_pg_sz);`**
+3. **`int reset_iommu(iommu_t *iommu, uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_limit, uint8_t num_vec_bits, uint8_t reset_iommu_mode, uint8_t max_iommu_mode, uint32_t max_devid_mask, uint8_t gxl_writeable, uint8_t fctl_be_writeable, uint8_t fill_ats_trans_in_ioatc, capabilities_t capabilities, fctl_t fctl, uint64_t sv57_bare_pg_sz, uint64_t sv48_bare_pg_sz, uint64_t sv39_bare_pg_sz, uint64_t sv32_bare_pg_sz, uint64_t sv57x4_bare_pg_sz, uint64_t sv48x4_bare_pg_sz, uint64_t sv39x4_bare_pg_sz, uint64_t sv32x4_bare_pg_sz);`**
 
 This function is provided by the reference model to establish the resset default state.
 The num_hpm indicates the number of hardware performace monitoring counters to be
@@ -123,25 +126,25 @@ parameter. The default value of the feature control register is provided by the 
 parameter. The function returns 0 if the reference model could be successfully initialized
 with the provided parameters.
 
-4. **`void iommu_translate_iova(hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp_msg)`**
+4. **`void iommu_translate_iova(iommu_t *iommu, hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp_msg)`**
 
 This function is used by the test bench to invoke the translation request interface in the
 IOMMU. The translation response is returned in the buffer pointed to by rsp_msg.
 
-5. **`void handle_page_request(ats_msg_t *pr)`**
+5. **`void handle_page_request(iommu_t *iommu, ats_msg_t *pr)`**
 
 This function is used by the test bench to send a page request message to the IOMMU.
 
-6. **`uint8_t handle_invalidation_completion(ats_msg_t *inv_cc)`**
+6. **`uint8_t handle_invalidation_completion(iommu_t *iommu, ats_msg_t *inv_cc)`**
 
 This function is used by the test bench to send a invalidation completion message to the IOMMU.
 
-7. **`void do_ats_timer_expiry(uint32_t itag_vector)`**
+7. **`void do_ats_timer_expiry(iommu_t *iommu, uint32_t itag_vector)`**
 
 This function is used by the test bench to signal a timeout for one or more ATS invalidation
 requests sent by the IOMMU.
 
-8. **`void process_commands(void)`**
+8. **`void process_commands(iommu_t *iommu)`**
 
 This function when invoked causes the IOMMU to process a command from the command queue. This
 function acts like a "clock" and in each invocation processes one command. If multiple command

--- a/iommu_ref_model/libiommu/include/iommu.h
+++ b/iommu_ref_model/libiommu/include/iommu.h
@@ -9,6 +9,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+typedef struct iommu_t iommu_t;
+
 #include "iommu_registers.h"
 #include "iommu_data_structures.h"
 #include "iommu_req_rsp.h"
@@ -21,5 +24,59 @@
 #include "iommu_atc.h"
 #include "iommu_hpm.h"
 #include "iommu_ref_api.h"
+
+typedef struct iommu_t {
+    // from iommu_command_queue.c
+    uint8_t command_queue_stall_for_itag;
+    uint8_t ats_inv_req_timeout;
+    uint8_t iofence_wait_pending_inv;
+    uint8_t iofence_pending_PR, iofence_pending_PW, iofence_pending_AV, iofence_pending_WSI_BIT;
+    uint64_t iofence_pending_ADDR;
+    uint32_t iofence_pending_DATA;
+
+    uint8_t pending_inval_req_DSV;
+    uint8_t pending_inval_req_DSEG;
+    uint16_t pending_inval_req_RID;
+    uint8_t pending_inval_req_PV;
+    uint32_t pending_inval_req_PID;
+    uint64_t pending_inval_req_PAYLOAD;
+
+    // iommu_reg.c
+    // IOMMU register file
+    iommu_regs_t reg_file;
+    // Register offset to size mapping
+    uint8_t offset_to_size[4096];
+    // Global parameters of the design
+    uint8_t num_hpm;
+    uint8_t hpmctr_bits;
+    uint8_t eventID_limit;
+    uint8_t num_vec_bits;
+    uint8_t gxl_writeable;
+    uint8_t fctl_be_writeable;
+    uint8_t max_iommu_mode;
+    uint8_t fill_ats_trans_in_ioatc;
+    uint32_t max_devid_mask;
+    uint8_t trans_for_debug;
+    uint64_t sv57_bare_pg_sz;
+    uint64_t sv48_bare_pg_sz;
+    uint64_t sv39_bare_pg_sz;
+    uint64_t sv32_bare_pg_sz;
+    uint64_t sv57x4_bare_pg_sz;
+    uint64_t sv48x4_bare_pg_sz;
+    uint64_t sv39x4_bare_pg_sz;
+    uint64_t sv32x4_bare_pg_sz;
+    iommu_qosid_t iommu_qosid_mask;
+
+    // from iommu_atc.
+    ddt_cache_t ddt_cache[DDT_CACHE_SIZE];
+    pdt_cache_t pdt_cache[PDT_CACHE_SIZE];
+    tlb_t       tlb[TLB_SIZE];
+    uint32_t    dc_lru_time;
+    uint32_t    pc_lru_time;
+    uint32_t    tlb_lru_time;
+
+    itag_tracker_t itag_tracker[MAX_ITAGS];
+    uint8_t msi_pending[16];
+} iommu_t;
 
 #endif

--- a/iommu_ref_model/libiommu/include/iommu_atc.h
+++ b/iommu_ref_model/libiommu/include/iommu_atc.h
@@ -58,16 +58,15 @@ typedef struct {
 #define IOATC_HIT   1
 #define IOATC_FAULT 2
 
-extern ddt_cache_t ddt_cache[DDT_CACHE_SIZE];
-extern pdt_cache_t pdt_cache[PDT_CACHE_SIZE];
-extern tlb_t       tlb[TLB_SIZE];
 extern void
 cache_ioatc_iotlb(
+    iommu_t *iommu,
     uint64_t vpn, uint8_t  GV, uint8_t  PSCV, uint32_t GSCID, uint32_t PSCID,
     pte_t *vs_pte, gpte_t *g_pte, uint64_t PPN, uint8_t S, uint8_t is_msi);
 
 extern uint8_t
 lookup_ioatc_iotlb(
+    iommu_t *iommu,
     uint64_t iova, uint8_t check_access_perms,
     uint8_t priv, uint8_t is_read, uint8_t is_write, uint8_t is_exec,
     uint8_t SUM, uint8_t PSCV, uint32_t PSCID, uint8_t GV, uint16_t GSCID,
@@ -75,15 +74,15 @@ lookup_ioatc_iotlb(
     pte_t *vs_pte, gpte_t *g_pteu, uint8_t *is_msi);
 
 extern uint8_t
-lookup_ioatc_dc(uint32_t device_id, device_context_t *DC);
+lookup_ioatc_dc(iommu_t *iommu, uint32_t device_id, device_context_t *DC);
 
 extern void
-cache_ioatc_dc(uint32_t device_id, device_context_t *DC);
+cache_ioatc_dc(iommu_t *iommu, uint32_t device_id, device_context_t *DC);
 
 extern uint8_t
-lookup_ioatc_pc(uint32_t device_id, uint32_t process_id, process_context_t *PC);
+lookup_ioatc_pc(iommu_t *iommu, uint32_t device_id, uint32_t process_id, process_context_t *PC);
 
 extern void
-cache_ioatc_pc(uint32_t device_id, uint32_t process_id, process_context_t *PC);
+cache_ioatc_pc(iommu_t *iommu, uint32_t device_id, uint32_t process_id, process_context_t *PC);
 
 #endif // __IOMMU_ATC_H__

--- a/iommu_ref_model/libiommu/include/iommu_ats.h
+++ b/iommu_ref_model/libiommu/include/iommu_ats.h
@@ -79,7 +79,7 @@ typedef struct {
 } itag_tracker_t;
 
 #define MAX_ITAGS 2
-extern uint8_t allocate_itag(uint8_t DSV, uint8_t DSEG, uint16_t RID, uint8_t *itag);
+extern uint8_t allocate_itag(iommu_t *iommu, uint8_t DSV, uint8_t DSEG, uint16_t RID, uint8_t *itag);
 extern void send_msg_iommu_to_hb(ats_msg_t *msg);
-extern uint8_t any_ats_invalidation_requests_pending(void);
+extern uint8_t any_ats_invalidation_requests_pending(iommu_t *iommu);
 #endif //__IOMMU_ATS_H__

--- a/iommu_ref_model/libiommu/include/iommu_command_queue.h
+++ b/iommu_ref_model/libiommu/include/iommu_command_queue.h
@@ -94,16 +94,15 @@ typedef union {
 
 #define CQ_ENTRY_SZ sizeof(command_t)
 
-void do_inval_ddt(uint8_t DV, uint32_t DID);
-void do_inval_pdt(uint32_t DID, uint32_t PID);
-void do_iotinval_vma(uint8_t GV, uint8_t AV, uint8_t NL, uint8_t PSCV, uint32_t
+void do_inval_ddt(iommu_t *iommu, uint8_t DV, uint32_t DID);
+void do_inval_pdt(iommu_t *iommu, uint32_t DID, uint32_t PID);
+void do_iotinval_vma(iommu_t *iommu, uint8_t GV, uint8_t AV, uint8_t NL, uint8_t PSCV, uint32_t
                      GSCID, uint32_t PSCID, uint64_t ADDR, uint8_t S);
-void do_iotinval_gvma(uint8_t GV, uint8_t AV, uint8_t NL, uint32_t GSCID,
+void do_iotinval_gvma(iommu_t *iommu, uint8_t GV, uint8_t AV, uint8_t NL, uint32_t GSCID,
                       uint64_t ADDR, uint8_t S);
-void do_ats_msg( uint8_t MSGCODE, uint8_t TAG, uint8_t DSV, uint8_t DSEG, uint16_t RID,
+void do_ats_msg(iommu_t *iommu, uint8_t MSGCODE, uint8_t TAG, uint8_t DSV, uint8_t DSEG, uint16_t RID,
                   uint8_t PV, uint32_t PID, uint64_t PAYLOAD);
-uint8_t do_iofence_c(uint8_t PR, uint8_t PW, uint8_t AV, uint8_t WIS_BIT, uint64_t ADDR, uint32_t DATA);
-void do_pending_iofence();
-void queue_any_blocked_ats_inval_req();
-extern uint8_t g_ats_inv_req_timeout;
+uint8_t do_iofence_c(iommu_t *iommu, uint8_t PR, uint8_t PW, uint8_t AV, uint8_t WIS_BIT, uint64_t ADDR, uint32_t DATA);
+void do_pending_iofence(iommu_t *iommu);
+void queue_any_blocked_ats_inval_req(iommu_t *iommu);
 #endif // __IOMMU_COMMAND_QUEUE_H__

--- a/iommu_ref_model/libiommu/include/iommu_fault.h
+++ b/iommu_ref_model/libiommu/include/iommu_fault.h
@@ -66,6 +66,6 @@ typedef union {
 
 #define FQ_ENTRY_SZ sizeof(fault_rec_t)
 
-extern void report_fault(uint16_t cause, uint64_t iotval, uint64_t iotval2, uint8_t TTYP, uint8_t dtf,
+extern void report_fault(iommu_t *iommu, uint16_t cause, uint64_t iotval, uint64_t iotval2, uint8_t TTYP, uint8_t dtf,
                   uint32_t device_id, uint8_t pid_valid, uint32_t process_id, uint8_t priv_req);
 #endif // __IOMMU_FAULT_H__

--- a/iommu_ref_model/libiommu/include/iommu_hpm.h
+++ b/iommu_ref_model/libiommu/include/iommu_hpm.h
@@ -26,6 +26,6 @@
 #define S_VS_PT_WALKS        7
 #define G_PT_WALKS           8
 
-void count_events(uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
+void count_events(iommu_t *iommu, uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
     uint32_t DID, uint8_t GSCV, uint32_t GSCID, uint16_t eventID);
 #endif // __IOMMU_PMU_H__

--- a/iommu_ref_model/libiommu/include/iommu_interrupt.h
+++ b/iommu_ref_model/libiommu/include/iommu_interrupt.h
@@ -12,6 +12,6 @@
 
 #define MSI_VEC_CTRL_MASK_BIT 1
 
-extern void generate_interrupt(uint8_t unit);
-extern void release_pending_interrupt(uint8_t vec);
+extern void generate_interrupt(iommu_t *iommu, uint8_t unit);
+extern void release_pending_interrupt(iommu_t *iommu, uint8_t vec);
 #endif // __IOMMU_INTERRUPT_H__

--- a/iommu_ref_model/libiommu/include/iommu_ref_api.h
+++ b/iommu_ref_model/libiommu/include/iommu_ref_api.h
@@ -14,12 +14,12 @@ extern uint8_t write_memory(char *data, uint64_t address, uint32_t size,
 extern uint8_t read_memory_test(uint64_t addr, uint8_t size, char *data);
 extern uint8_t write_memory_test(char *data, uint64_t address, uint32_t size);
 
-extern uint64_t read_register(uint16_t offset, uint8_t num_bytes);
-extern void write_register(uint16_t offset, uint8_t num_bytes, uint64_t data);
+extern uint64_t read_register(iommu_t *iommu, uint16_t offset, uint8_t num_bytes);
+extern void write_register(iommu_t *iommu, uint16_t offset, uint8_t num_bytes, uint64_t data);
 
 #define FILL_IOATC_ATS_T2GPA  0x01
 #define FILL_IOATC_ATS_ALWAYS 0x02
-extern int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_limit,
+extern int reset_iommu(iommu_t *iommu, uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_limit,
                        uint8_t num_vec_bits, uint8_t reset_iommu_mode,
                        uint8_t max_iommu_mode, uint32_t max_devid_mask,
                        uint8_t gxl_writeable, uint8_t fctl_be_writeable,
@@ -28,11 +28,11 @@ extern int reset_iommu(uint8_t num_hpm, uint8_t hpmctr_bits, uint16_t eventID_li
                        uint64_t sv39_bare_pg_sz, uint64_t sv32_bare_pg_sz,
                        uint64_t sv57x4_bare_pg_sz, uint64_t sv48x4_bare_pg_sz,
                        uint64_t sv39x4_bare_pg_sz, uint64_t sv32x4_bare_pg_sz);
-extern void iommu_translate_iova(hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp_msg);
-extern void handle_page_request(ats_msg_t *pr);
-extern uint8_t handle_invalidation_completion(ats_msg_t *inv_cc);
-extern void do_ats_timer_expiry(uint32_t itag_vector);
-extern void process_commands(void);
+extern void iommu_translate_iova(iommu_t *iommu, hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp_msg);
+extern void handle_page_request(iommu_t *iommu, ats_msg_t *pr);
+extern uint8_t handle_invalidation_completion(iommu_t *iommu, ats_msg_t *inv_cc);
+extern void do_ats_timer_expiry(iommu_t *iommu, uint32_t itag_vector);
+extern void process_commands(iommu_t *iommu);
 
 extern void iommu_to_hb_do_global_observability_sync(uint8_t PR, uint8_t PW);
 extern void send_msg_iommu_to_hb(ats_msg_t *prgr);

--- a/iommu_ref_model/libiommu/include/iommu_registers.h
+++ b/iommu_ref_model/libiommu/include/iommu_registers.h
@@ -805,27 +805,5 @@ typedef union {                        // |Ofst|Name            |Size|Descriptio
 #define DDT_2LVL 3
 #define DDT_3LVL 4
 
-extern iommu_regs_t g_reg_file;
-extern uint8_t g_num_hpm;
-extern uint8_t g_hpmctr_bits;
-extern uint8_t g_eventID_limit;
-extern uint8_t g_num_vec_bits;
-extern uint8_t g_gxl_writeable;
-extern uint8_t g_fctl_be_writeable;
-extern uint8_t g_offset_to_size[4096];
-extern uint8_t g_max_iommu_mode;
-extern uint8_t g_fill_ats_trans_in_ioatc;
-extern uint32_t g_max_devid_mask;
-extern uint8_t g_trans_for_debug;
-extern uint64_t g_sv57_bare_pg_sz;
-extern uint64_t g_sv48_bare_pg_sz;
-extern uint64_t g_sv39_bare_pg_sz;
-extern uint64_t g_sv32_bare_pg_sz;
-extern uint64_t g_sv57x4_bare_pg_sz;
-extern uint64_t g_sv48x4_bare_pg_sz;
-extern uint64_t g_sv39x4_bare_pg_sz;
-extern uint64_t g_sv32x4_bare_pg_sz;
-extern iommu_qosid_t g_iommu_qosid_mask;
-
-extern void process_commands(void);
+extern void process_commands(iommu_t *iommu);
 #endif //_IOMMU_REGS_H_

--- a/iommu_ref_model/libiommu/include/iommu_translate.h
+++ b/iommu_ref_model/libiommu/include/iommu_translate.h
@@ -84,18 +84,18 @@ typedef union {
 
 
 extern uint8_t
-locate_device_context(device_context_t *DC, uint32_t device_id, uint8_t pid_valid,
+locate_device_context(iommu_t *iommu, device_context_t *DC, uint32_t device_id, uint8_t pid_valid,
                       uint32_t process_id, uint32_t *cause);
 
 extern uint8_t
-locate_process_context(process_context_t *PC, device_context_t *DC,
+locate_process_context(iommu_t *iommu, process_context_t *PC, device_context_t *DC,
                        uint32_t device_id, uint32_t process_id, uint32_t *cause,
                        uint64_t *iotval2, uint8_t TTYP, uint8_t is_orig_read,
                        uint8_t is_orig_write, uint8_t is_orig_exec);
 
 extern uint8_t
 two_stage_address_translation(
-    uint64_t iova, uint8_t TTYP, uint32_t DID, uint8_t is_read,
+    iommu_t *iommu, uint64_t iova, uint8_t TTYP, uint32_t DID, uint8_t is_read,
     uint8_t is_write, uint8_t is_exec,
     uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
     iosatp_t iosatp, uint8_t priv, uint8_t SUM, uint8_t SADE,
@@ -105,7 +105,7 @@ two_stage_address_translation(
 
 extern uint8_t
 second_stage_address_translation(
-    uint64_t gpa, uint8_t check_access_perms, uint32_t DID,
+    iommu_t *iommu, uint64_t gpa, uint8_t check_access_perms, uint32_t DID,
     uint8_t is_read, uint8_t is_write, uint8_t is_exec, uint8_t is_implicit,
     uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
     uint8_t GV, uint32_t GSCID, iohgatp_t iohgatp, uint8_t GADE, uint8_t SADE, uint8_t SXL,
@@ -113,7 +113,7 @@ second_stage_address_translation(
 
 extern uint8_t
 msi_address_translation(
-    uint64_t gpa, uint8_t is_exec, device_context_t *DC,
+    iommu_t *iommu, uint64_t gpa, uint8_t is_exec, device_context_t *DC,
     uint8_t *is_msi, uint8_t *is_mrif, uint32_t *mrif_nid, uint64_t *dest_mrif_addr,
     uint32_t *cause, uint64_t *iotval2, uint64_t *pa,
     uint64_t *page_sz, gpte_t *g_pte, uint8_t check_access_perms, uint32_t rcid,

--- a/iommu_ref_model/libiommu/src/iommu_atc.c
+++ b/iommu_ref_model/libiommu/src/iommu_atc.c
@@ -3,49 +3,45 @@
 // SPDX-License-Identifier: Apache-2.0
 // Author: ved@rivosinc.com
 #include "iommu.h"
-ddt_cache_t ddt_cache[DDT_CACHE_SIZE];
-pdt_cache_t pdt_cache[2];
-tlb_t       tlb[2];
-uint32_t    dc_lru_time = 0;
-uint32_t    pc_lru_time = 0;
-uint32_t    tlb_lru_time = 0;
 
 // Cache a device context
 void
 cache_ioatc_dc(
+    iommu_t *iommu,
     uint32_t device_id, device_context_t *DC) {
     uint8_t i, replace;
     uint32_t lru = 0xFFFFFFFF;
 
     for ( i = 0; i < DDT_CACHE_SIZE; i++ ) {
-        if ( ddt_cache[i].valid == 0 ) {
+        if ( iommu->ddt_cache[i].valid == 0 ) {
             replace = i;
             break;
         }
     }
     if ( i == DDT_CACHE_SIZE ) {
         for ( i = 0; i < DDT_CACHE_SIZE; i++ ) {
-            if ( ddt_cache[i].lru < lru ) {
+            if ( iommu->ddt_cache[i].lru < lru ) {
                 replace = i;
-                lru = ddt_cache[i].lru;
+                lru = iommu->ddt_cache[i].lru;
             }
         }
     }
-    ddt_cache[replace].DC = *DC;
-    ddt_cache[replace].DID = device_id;
-    ddt_cache[replace].valid = 1;
+    iommu->ddt_cache[replace].DC = *DC;
+    iommu->ddt_cache[replace].DID = device_id;
+    iommu->ddt_cache[replace].valid = 1;
     return;
 }
 
 // Lookup IOATC for a device context
 uint8_t
 lookup_ioatc_dc(
+    iommu_t *iommu,
     uint32_t device_id, device_context_t *DC) {
     uint8_t i;
     for ( i = 0; i < DDT_CACHE_SIZE; i++ ) {
-        if ( ddt_cache[i].valid == 1 && ddt_cache[i].DID == device_id ) {
-            *DC = ddt_cache[i].DC;
-            ddt_cache[i].lru = dc_lru_time++;
+        if ( iommu->ddt_cache[i].valid == 1 && iommu->ddt_cache[i].DID == device_id ) {
+            *DC = iommu->ddt_cache[i].DC;
+            iommu->ddt_cache[i].lru = iommu->dc_lru_time++;
             return IOATC_HIT;
         }
     }
@@ -54,41 +50,43 @@ lookup_ioatc_dc(
 // Cache a process context
 void
 cache_ioatc_pc(
+    iommu_t *iommu,
     uint32_t device_id, uint32_t process_id, process_context_t *PC) {
     uint8_t i, replace = 0;
     uint32_t lru = 0xFFFFFFFF;
 
     for ( i = 0; i < PDT_CACHE_SIZE; i++ ) {
-        if ( pdt_cache[i].valid == 0 ) {
+        if ( iommu->pdt_cache[i].valid == 0 ) {
             replace = i;
             break;
         }
     }
     if ( i == PDT_CACHE_SIZE ) {
         for ( i = 0; i < PDT_CACHE_SIZE; i++ ) {
-            if ( pdt_cache[i].lru < lru ) {
+            if ( iommu->pdt_cache[i].lru < lru ) {
                 replace = i;
-                lru = pdt_cache[i].lru;
+                lru = iommu->pdt_cache[i].lru;
             }
         }
     }
-    pdt_cache[replace].PC = *PC;
-    pdt_cache[replace].DID = device_id;
-    pdt_cache[replace].PID = process_id;
-    pdt_cache[replace].valid = 1;
+    iommu->pdt_cache[replace].PC = *PC;
+    iommu->pdt_cache[replace].DID = device_id;
+    iommu->pdt_cache[replace].PID = process_id;
+    iommu->pdt_cache[replace].valid = 1;
     return;
 }
 // Lookup IOATC for a process context
 uint8_t
 lookup_ioatc_pc(
+    iommu_t *iommu,
     uint32_t device_id, uint32_t process_id, process_context_t *PC) {
     uint8_t i;
     for ( i = 0; i < PDT_CACHE_SIZE; i++ ) {
-        if ( pdt_cache[i].valid == 1 &&
-             pdt_cache[i].DID == device_id &&
-             pdt_cache[i].PID == process_id ) {
-            *PC = pdt_cache[i].PC;
-            pdt_cache[i].lru = pc_lru_time++;
+        if ( iommu->pdt_cache[i].valid == 1 &&
+             iommu->pdt_cache[i].DID == device_id &&
+             iommu->pdt_cache[i].PID == process_id ) {
+            *PC = iommu->pdt_cache[i].PC;
+            iommu->pdt_cache[i].lru = iommu->pc_lru_time++;
             return 1;
         }
     }
@@ -97,6 +95,7 @@ lookup_ioatc_pc(
 // Cache a translation in the IOATC
 void
 cache_ioatc_iotlb(
+    iommu_t *iommu,
     uint64_t vpn, uint8_t  GV, uint8_t  PSCV, uint32_t GSCID, uint32_t PSCID,
     pte_t *vs_pte, gpte_t *g_pte, uint64_t PPN, uint8_t S, uint8_t IS_MSI) {
 
@@ -104,52 +103,53 @@ cache_ioatc_iotlb(
     uint32_t lru = 0xFFFFFFFF;
 
     for ( i = 0; i < TLB_SIZE; i++ ) {
-        if ( tlb[i].valid == 0 ) {
+        if ( iommu->tlb[i].valid == 0 ) {
             replace = i;
             break;
         }
     }
     if ( i == TLB_SIZE ) {
         for ( i = 0; i < TLB_SIZE; i++ ) {
-            if ( tlb[i].lru < lru ) {
+            if ( iommu->tlb[i].lru < lru ) {
                 replace = i;
-                lru = tlb[i].lru;
+                lru = iommu->tlb[i].lru;
             }
         }
     }
 
     // Fill the tags
-    tlb[replace].vpn   = vpn;
-    tlb[replace].GV    = GV;
-    tlb[replace].PSCV  = PSCV;
-    tlb[replace].GSCID = GSCID;
-    tlb[replace].PSCID = PSCID;
+    iommu->tlb[replace].vpn   = vpn;
+    iommu->tlb[replace].GV    = GV;
+    iommu->tlb[replace].PSCV  = PSCV;
+    iommu->tlb[replace].GSCID = GSCID;
+    iommu->tlb[replace].PSCID = PSCID;
     // Fill VS stage attributes
-    tlb[replace].VS_R  = vs_pte->R;
-    tlb[replace].VS_W  = vs_pte->W;
-    tlb[replace].VS_X  = vs_pte->X;
-    tlb[replace].VS_D  = vs_pte->D;
-    tlb[replace].U     = vs_pte->U;
-    tlb[replace].G     = vs_pte->G;
-    tlb[replace].PBMT  = vs_pte->PBMT;
+    iommu->tlb[replace].VS_R  = vs_pte->R;
+    iommu->tlb[replace].VS_W  = vs_pte->W;
+    iommu->tlb[replace].VS_X  = vs_pte->X;
+    iommu->tlb[replace].VS_D  = vs_pte->D;
+    iommu->tlb[replace].U     = vs_pte->U;
+    iommu->tlb[replace].G     = vs_pte->G;
+    iommu->tlb[replace].PBMT  = vs_pte->PBMT;
     // Fill G stage attributes
-    tlb[replace].G_R   = g_pte->R;
-    tlb[replace].G_W   = g_pte->W;
-    tlb[replace].G_X   = g_pte->X;
-    tlb[replace].G_D   = g_pte->D;
+    iommu->tlb[replace].G_R   = g_pte->R;
+    iommu->tlb[replace].G_W   = g_pte->W;
+    iommu->tlb[replace].G_X   = g_pte->X;
+    iommu->tlb[replace].G_D   = g_pte->D;
     // PPN and size
-    tlb[replace].PPN   = PPN;
-    tlb[replace].S     = S;
+    iommu->tlb[replace].PPN   = PPN;
+    iommu->tlb[replace].S     = S;
     // Whether MSI
-    tlb[replace].IS_MSI = IS_MSI;
+    iommu->tlb[replace].IS_MSI = IS_MSI;
 
-    tlb[replace].valid = 1;
+    iommu->tlb[replace].valid = 1;
     return;
 }
 
 // Lookup a translation in the IOATC
 uint8_t
 lookup_ioatc_iotlb(
+    iommu_t *iommu,
     uint64_t iova, uint8_t check_access_perms,
     uint8_t priv, uint8_t is_read, uint8_t is_write, uint8_t is_exec,
     uint8_t SUM, uint8_t PSCV, uint32_t PSCID, uint8_t GV, uint16_t GSCID,
@@ -161,10 +161,10 @@ lookup_ioatc_iotlb(
 
     hit = 0xFF;
     for ( i = 0; i < TLB_SIZE; i++ ) {
-        if ( tlb[i].valid == 1 &&
-             tlb[i].GV == GV && tlb[i].GSCID == GSCID &&
-             tlb[i].PSCV == PSCV && tlb[i].PSCID == PSCID &&
-             match_address_range(vpn, 0, tlb[i].vpn, tlb[i].S) ) {
+        if ( iommu->tlb[i].valid == 1 &&
+             iommu->tlb[i].GV == GV && iommu->tlb[i].GSCID == GSCID &&
+             iommu->tlb[i].PSCV == PSCV && iommu->tlb[i].PSCID == PSCID &&
+             match_address_range(vpn, 0, iommu->tlb[i].vpn, iommu->tlb[i].S) ) {
             hit = i;
             break;
         }
@@ -172,23 +172,23 @@ lookup_ioatc_iotlb(
     if ( hit == 0xFF ) return IOATC_MISS;
 
     // Age the entries
-    tlb[i].lru = tlb_lru_time++;
+    iommu->tlb[i].lru = iommu->tlb_lru_time++;
 
     // Check S/VS stage permissions
     if ( check_access_perms == 1 ) {
-        if ( is_exec  && (tlb[hit].VS_X == 0) ) goto page_fault;
-        if ( is_read  && (tlb[hit].VS_R == 0) ) goto page_fault;
-        if ( is_write && (tlb[hit].VS_W == 0) ) goto page_fault;
+        if ( is_exec  && (iommu->tlb[hit].VS_X == 0) ) goto page_fault;
+        if ( is_read  && (iommu->tlb[hit].VS_R == 0) ) goto page_fault;
+        if ( is_write && (iommu->tlb[hit].VS_W == 0) ) goto page_fault;
     }
     // U and SUM bit based checks are active only when iosatp.MODE is not Bare
-    if ( (PSCV == 1) && (priv == U_MODE) && (tlb[hit].U == 0) ) goto page_fault;
-    if ( (PSCV == 1) && is_exec && (priv == S_MODE) && (tlb[hit].U == 1) ) goto page_fault;
-    if ( (PSCV == 1) && (priv == S_MODE) && !is_exec && SUM == 0 && tlb[hit].U == 1 ) goto page_fault;
+    if ( (PSCV == 1) && (priv == U_MODE) && (iommu->tlb[hit].U == 0) ) goto page_fault;
+    if ( (PSCV == 1) && is_exec && (priv == S_MODE) && (iommu->tlb[hit].U == 1) ) goto page_fault;
+    if ( (PSCV == 1) && (priv == S_MODE) && !is_exec && SUM == 0 && iommu->tlb[hit].U == 1 ) goto page_fault;
 
     // Check G stage permissions
-    if ( (is_exec  && (tlb[hit].G_X == 0)) ||
-         (is_read  && (tlb[hit].G_R == 0)) ||
-         (is_write && (tlb[hit].G_W == 0)) ) {
+    if ( (is_exec  && (iommu->tlb[hit].G_X == 0)) ||
+         (is_read  && (iommu->tlb[hit].G_R == 0)) ||
+         (is_write && (iommu->tlb[hit].G_W == 0)) ) {
         // More commonly, implementations contain address-translation caches that
         // map guest virtual addresses directly to supervisor physical addresses,
         // removing a level of indirection.
@@ -196,30 +196,30 @@ lookup_ioatc_iotlb(
         // GPA to report in the iotval2. A common technique is to treat it as a
         // TLB miss and trigger a page walk such that the GPA can be reported if
         // the fault is actually detected again by the G-stage page tables
-        tlb[hit].valid = 0;
+        iommu->tlb[hit].valid = 0;
         return IOATC_MISS;
     }
     // If memory access is a store and VS/S or G stage D bit is 0 then mark
     // TLB entry as invalid so it returns a miss to trigger a page walk
-    if ( (tlb[hit].VS_D == 0 || tlb[hit].G_D == 0) && is_write == 1 ) {
-        tlb[hit].valid = 0;
+    if ( (iommu->tlb[hit].VS_D == 0 || iommu->tlb[hit].G_D == 0) && is_write == 1 ) {
+        iommu->tlb[hit].valid = 0;
         return IOATC_MISS;
     }
-    *page_sz = ((tlb[hit].S == 0) ? 1 : ((tlb[hit].PPN ^ (tlb[hit].PPN + 1)) + 1));
+    *page_sz = ((iommu->tlb[hit].S == 0) ? 1 : ((iommu->tlb[hit].PPN ^ (iommu->tlb[hit].PPN + 1)) + 1));
     *page_sz = *page_sz * PAGESIZE;
-    *resp_pa = ((tlb[hit].PPN * PAGESIZE) & ~(*page_sz - 1)) | (iova & (*page_sz - 1));
-    g_pte->R = tlb[hit].G_R;
-    g_pte->W = tlb[hit].G_W;
-    g_pte->X = tlb[hit].G_X;
+    *resp_pa = ((iommu->tlb[hit].PPN * PAGESIZE) & ~(*page_sz - 1)) | (iova & (*page_sz - 1));
+    g_pte->R = iommu->tlb[hit].G_R;
+    g_pte->W = iommu->tlb[hit].G_W;
+    g_pte->X = iommu->tlb[hit].G_X;
 
-    vs_pte->R = tlb[hit].VS_R;
-    vs_pte->W = tlb[hit].VS_W;
-    vs_pte->X = tlb[hit].VS_X;
-    vs_pte->G = tlb[hit].G;
-    vs_pte->U = tlb[hit].U;
-    vs_pte->PBMT = tlb[hit].PBMT;
+    vs_pte->R = iommu->tlb[hit].VS_R;
+    vs_pte->W = iommu->tlb[hit].VS_W;
+    vs_pte->X = iommu->tlb[hit].VS_X;
+    vs_pte->G = iommu->tlb[hit].G;
+    vs_pte->U = iommu->tlb[hit].U;
+    vs_pte->PBMT = iommu->tlb[hit].PBMT;
 
-    *is_msi = tlb[hit].IS_MSI;
+    *is_msi = iommu->tlb[hit].IS_MSI;
     return IOATC_HIT;
 
 page_fault:

--- a/iommu_ref_model/libiommu/src/iommu_device_context.c
+++ b/iommu_ref_model/libiommu/src/iommu_device_context.c
@@ -4,14 +4,14 @@
 // Author: ved@rivosinc.com
 
 #include "iommu.h"
-uint8_t do_device_context_configuration_checks(device_context_t *DC);
+uint8_t do_device_context_configuration_checks(iommu_t *iommu, device_context_t *DC);
 
 uint8_t
 locate_device_context(
-    device_context_t *DC, uint32_t device_id,
+    iommu_t *iommu, device_context_t *DC, uint32_t device_id,
     uint8_t pid_valid, uint32_t process_id, uint32_t *cause) {
     uint64_t a;
-    uint64_t pa_mask = ((1UL << (g_reg_file.capabilities.pas)) - 1);
+    uint64_t pa_mask = ((1UL << (iommu->reg_file.capabilities.pas)) - 1);
     uint8_t i, LEVELS, status, DC_SIZE;
     ddte_t ddte;
     uint16_t DDI[3];
@@ -70,7 +70,7 @@ locate_device_context(
     // If `capabilities.MSI_FLAT` is 0 then the IOMMU uses base-format device
     // context. Let `DDI[0]` be `device_id[6:0]`, `DDI[1]` be `device_id[15:7]`, and
     // `DDI[2]` be `device_id[23:16]`.
-    if ( g_reg_file.capabilities.msi_flat == 0 ) {
+    if ( iommu->reg_file.capabilities.msi_flat == 0 ) {
         DDI[0] = get_bits(6,   0, device_id);
         DDI[1] = get_bits(15,  7, device_id);
         DDI[2] = get_bits(23, 16, device_id);
@@ -78,14 +78,14 @@ locate_device_context(
     // If `capabilities.MSI_FLAT` is 1 then the IOMMU uses extended-format device
     // context. Let `DDI[0]` be `device_id[5:0]`, `DDI[1]` be `device_id[14:6]`, and
     // `DDI[2]` be `device_id[23:15]`.
-    if ( g_reg_file.capabilities.msi_flat == 1 ) {
+    if ( iommu->reg_file.capabilities.msi_flat == 1 ) {
         DDI[0] = get_bits(5,   0, device_id);
         DDI[1] = get_bits(14,  6, device_id);
         DDI[2] = get_bits(23, 15, device_id);
     }
 
     // Determine if there is a cached device context
-    if ( lookup_ioatc_dc(device_id, DC) == IOATC_HIT )
+    if ( lookup_ioatc_dc(iommu, device_id, DC) == IOATC_HIT )
         return 0;
 
     // The process to locate the Device-context for transaction
@@ -93,10 +93,10 @@ locate_device_context(
     // 1. Let `a` be `ddtp.PPN x 2^12^` and let `i = LEVELS - 1`. When
     //    `ddtp.iommu_mode` is `3LVL`, `LEVELS` is three. When `ddtp.iommu_mode` is
     //    `2LVL`, `LEVELS` is two. When `ddtp.iommu_mode` is `1LVL`, `LEVELS` is one.
-    a = g_reg_file.ddtp.ppn * PAGESIZE;
-    if ( g_reg_file.ddtp.iommu_mode == DDT_3LVL ) LEVELS = 3;
-    if ( g_reg_file.ddtp.iommu_mode == DDT_2LVL ) LEVELS = 2;
-    if ( g_reg_file.ddtp.iommu_mode == DDT_1LVL ) LEVELS = 1;
+    a = iommu->reg_file.ddtp.ppn * PAGESIZE;
+    if ( iommu->reg_file.ddtp.iommu_mode == DDT_3LVL ) LEVELS = 3;
+    if ( iommu->reg_file.ddtp.iommu_mode == DDT_2LVL ) LEVELS = 2;
+    if ( iommu->reg_file.ddtp.iommu_mode == DDT_1LVL ) LEVELS = 1;
     i = LEVELS - 1;
 
 step_2:
@@ -104,7 +104,7 @@ step_2:
     if ( i == 0 ) goto step_8;
 
     // Count walks in DDT
-    count_events(pid_valid, process_id, 0, 0, device_id, 0, 0, DDT_WALKS);
+    count_events(iommu, pid_valid, process_id, 0, 0, device_id, 0, 0, DDT_WALKS);
 
     // 3. Let `ddte` be value of eight bytes at address `a + DDI[i] x 8`. If accessing
     //    `ddte` violates a PMA or PMP check, then stop and report "DDT entry load
@@ -112,8 +112,8 @@ step_2:
     status = (a  & ~pa_mask) ?
              ACCESS_FAULT :
              read_memory((a + (DDI[i] * 8)), 8, (char *)&ddte.raw,
-                         g_reg_file.iommu_qosid.rcid,
-                         g_reg_file.iommu_qosid.mcid, PMA);
+                         iommu->reg_file.iommu_qosid.rcid,
+                         iommu->reg_file.iommu_qosid.mcid, PMA);
     if ( status & ACCESS_FAULT ) {
         *cause = 257;     // DDT entry load access fault
         return 1;
@@ -148,7 +148,7 @@ step_2:
 
 step_8:
     // Count walks in DDT
-    count_events(pid_valid, process_id, 0, 0, device_id, 0, 0, DDT_WALKS);
+    count_events(iommu, pid_valid, process_id, 0, 0, device_id, 0, 0, DDT_WALKS);
 
     // 8. Let `DC` be value of `DC_SIZE` bytes at address `a + DDI[0] * DC_SIZE`. If
     //    `capabilities.MSI_FLAT` is 1 then `DC_SIZE` is 64-bytes else it is 32-bytes.
@@ -157,12 +157,12 @@ step_8:
     //    corruption (a.k.a. poisoned data), then stop and report "DDT data corruption"
     //    (cause = 268). This fault is detected if the IOMMU supports the RAS capability
     //    (`capabilities.RAS == 1`).
-    DC_SIZE = ( g_reg_file.capabilities.msi_flat == 1 ) ? EXT_FORMAT_DC_SIZE : BASE_FORMAT_DC_SIZE;
+    DC_SIZE = ( iommu->reg_file.capabilities.msi_flat == 1 ) ? EXT_FORMAT_DC_SIZE : BASE_FORMAT_DC_SIZE;
     status = ((a + (DDI[0] * DC_SIZE)) & ~pa_mask) ?
              ACCESS_FAULT :
              read_memory((a + (DDI[0] * DC_SIZE)), DC_SIZE, (char *)DC,
-                         g_reg_file.iommu_qosid.rcid,
-                         g_reg_file.iommu_qosid.mcid, PMA);
+                         iommu->reg_file.iommu_qosid.rcid,
+                         iommu->reg_file.iommu_qosid.mcid, PMA);
     if ( status & ACCESS_FAULT ) {
         *cause = 257;     // DDT entry load access fault
         return 1;
@@ -176,17 +176,17 @@ step_8:
         *cause = 258;     // DDT entry not valid
         return 1;
     }
-    if ( do_device_context_configuration_checks(DC) ) {
+    if ( do_device_context_configuration_checks(iommu, DC) ) {
         *cause = 259;     // DDT entry misconfigured
         return 1;
     }
     //12. The device-context has been successfully located and may be cached.
-    cache_ioatc_dc(device_id, DC);
+    cache_ioatc_dc(iommu, device_id, DC);
     return 0;
 }
 uint8_t
 do_device_context_configuration_checks(
-    device_context_t *DC) {
+    iommu_t *iommu, device_context_t *DC) {
 
     // A `DC` with `V=1` is determined to be misconfigured if any of the following
     // conditions are true. If misconfigured then stop and report "DDT entry
@@ -195,23 +195,23 @@ do_device_context_configuration_checks(
     // 1. If any bits or encoding that are reserved for future standard use are set.
     //    The RCID and MCID fields are added by the QoS ID extension. If capabilities.QOSID
     //    is 0, these bits are reserved and must be set to 0.
-    if ( ((g_reg_file.capabilities.msi_flat == 1) && (DC->reserved != 0)) ||
-         ((g_reg_file.capabilities.msi_flat == 1) && (DC->msiptp.reserved != 0)) ||
-         ((g_reg_file.capabilities.msi_flat == 1) && (DC->msi_addr_mask.reserved != 0)) ||
-         ((g_reg_file.capabilities.msi_flat == 1) && (DC->msi_addr_pattern.reserved != 0)) ||
+    if ( ((iommu->reg_file.capabilities.msi_flat == 1) && (DC->reserved != 0)) ||
+         ((iommu->reg_file.capabilities.msi_flat == 1) && (DC->msiptp.reserved != 0)) ||
+         ((iommu->reg_file.capabilities.msi_flat == 1) && (DC->msi_addr_mask.reserved != 0)) ||
+         ((iommu->reg_file.capabilities.msi_flat == 1) && (DC->msi_addr_pattern.reserved != 0)) ||
          (DC->tc.reserved0 != 0) ||
          (DC->tc.reserved1 != 0) ||
          (DC->fsc.pdtp.reserved != 0 && DC->tc.PDTV == 1) ||
          (DC->fsc.iosatp.reserved != 0 && DC->tc.PDTV == 0) ||
          (DC->ta.reserved0 != 0) ||
          (DC->ta.reserved1 != 0) ||
-         (g_reg_file.capabilities.qosid == 0 && (DC->ta.rcid != 0 || DC->ta.mcid != 0)) ) {
+         (iommu->reg_file.capabilities.qosid == 0 && (DC->ta.rcid != 0 || DC->ta.mcid != 0)) ) {
         return 1;
     }
     // 2. `capabilities.ATS` is 0 and `DC.tc.EN_ATS`, or `DC.tc.EN_PRI`,
     //     or `DC.tc.PRPR` is 1
     if ( ((DC->tc.EN_ATS == 1 || DC->tc.EN_PRI == 1 || DC->tc.PRPR == 1) &&
-          (g_reg_file.capabilities.ats == 0)) ) {
+          (iommu->reg_file.capabilities.ats == 0)) ) {
         return 1;
     }
     // 3. `DC.tc.EN_ATS` is 0 and `DC.tc.T2GPA` is 1
@@ -227,7 +227,7 @@ do_device_context_configuration_checks(
         return 1;
     }
     // 6. `capabilities.T2GPA` is 0 and `DC.tc.T2GPA` is 1
-    if ( DC->tc.T2GPA && (g_reg_file.capabilities.t2gpa == 0) ) {
+    if ( DC->tc.T2GPA && (iommu->reg_file.capabilities.t2gpa == 0) ) {
         return 1;
     }
     // 7. `DC.tc.T2GPA` is 1 and `DC.iohgatp.MODE` is `Bare`
@@ -246,9 +246,9 @@ do_device_context_configuration_checks(
         return 1;
     }
     if ( (DC->tc.PDTV == 1) &&
-         (((DC->fsc.pdtp.MODE == PD20) && (g_reg_file.capabilities.pd20 == 0)) ||
-          ((DC->fsc.pdtp.MODE == PD17) && (g_reg_file.capabilities.pd17 == 0)) ||
-          ((DC->fsc.pdtp.MODE == PD8) && (g_reg_file.capabilities.pd8 == 0))) ) {
+         (((DC->fsc.pdtp.MODE == PD20) && (iommu->reg_file.capabilities.pd20 == 0)) ||
+          ((DC->fsc.pdtp.MODE == PD17) && (iommu->reg_file.capabilities.pd17 == 0)) ||
+          ((DC->fsc.pdtp.MODE == PD8) && (iommu->reg_file.capabilities.pd8 == 0))) ) {
         return 1;
     }
     // 9. `DC.tc.PDTV` is 0 and `DC.fsc.iosatp.MODE` encoding is not valid
@@ -271,16 +271,16 @@ do_device_context_configuration_checks(
     //    .. `capabilities.Sv48` is 0 and `DC.fsc.iosatp.MODE` is `Sv48`
     //    .. `capabilities.Sv57` is 0 and `DC.fsc.iosatp.MODE` is `Sv57`
     if ( (DC->tc.PDTV == 0) &&  (DC->tc.SXL == 0) &&
-         (((DC->fsc.iosatp.MODE == IOSATP_Sv39) && (g_reg_file.capabilities.Sv39 == 0)) ||
-          ((DC->fsc.iosatp.MODE == IOSATP_Sv48) && (g_reg_file.capabilities.Sv48 == 0)) ||
-          ((DC->fsc.iosatp.MODE == IOSATP_Sv57) && (g_reg_file.capabilities.Sv57 == 0))) ) {
+         (((DC->fsc.iosatp.MODE == IOSATP_Sv39) && (iommu->reg_file.capabilities.Sv39 == 0)) ||
+          ((DC->fsc.iosatp.MODE == IOSATP_Sv48) && (iommu->reg_file.capabilities.Sv48 == 0)) ||
+          ((DC->fsc.iosatp.MODE == IOSATP_Sv57) && (iommu->reg_file.capabilities.Sv57 == 0))) ) {
         return 1;
     }
     //11. `DC.tc.PDTV` is 0 and and `DC.tc.SXL` is 1 `DC.fsc.iosatp.MODE` is not one of the
     //    supported modes
     //    .. `capabilities.Sv32` is 0 and `DC.fsc.iosatp.MODE` is `Sv32`
     if ( (DC->tc.PDTV == 0) &&  (DC->tc.SXL == 1) &&
-         ((DC->fsc.iosatp.MODE == IOSATP_Sv32) && (g_reg_file.capabilities.Sv32 == 0)) ) {
+         ((DC->fsc.iosatp.MODE == IOSATP_Sv32) && (iommu->reg_file.capabilities.Sv32 == 0)) ) {
         return 1;
     }
     //12. `DC.tc.PDTV` is 0 and `DC.tc.DPE` is 1
@@ -289,14 +289,14 @@ do_device_context_configuration_checks(
     }
     //13. `DC.iohgatp.MODE` encoding is not a valid encoding as determined
     //    by <<IOHGATP_MODE_ENC>>
-    if ( (g_reg_file.fctl.gxl == 0) &&
+    if ( (iommu->reg_file.fctl.gxl == 0) &&
          (DC->iohgatp.MODE != IOHGATP_Bare) &&
          (DC->iohgatp.MODE != IOHGATP_Sv39x4) &&
          (DC->iohgatp.MODE != IOHGATP_Sv48x4) &&
          (DC->iohgatp.MODE != IOHGATP_Sv57x4) ) {
         return 1;
     }
-    if ( (g_reg_file.fctl.gxl == 1) &&
+    if ( (iommu->reg_file.fctl.gxl == 1) &&
          (DC->iohgatp.MODE != IOHGATP_Bare) &&
          (DC->iohgatp.MODE != IOHGATP_Sv32x4) ) {
         return 1;
@@ -305,21 +305,21 @@ do_device_context_configuration_checks(
     //    a. `capabilities.Sv39x4` is 0 and `DC.iohgatp.MODE` is `Sv39x4`
     //    b. `capabilities.Sv48x4` is 0 and `DC.iohgatp.MODE` is `Sv48x4`
     //    c. `capabilities.Sv57x4` is 0 and `DC.iohgatp.MODE` is `Sv57x4`
-    if ( (g_reg_file.fctl.gxl == 0) &&
-         (((DC->iohgatp.MODE == IOHGATP_Sv39x4) && (g_reg_file.capabilities.Sv39x4 == 0)) ||
-          ((DC->iohgatp.MODE == IOHGATP_Sv48x4) && (g_reg_file.capabilities.Sv48x4 == 0)) ||
-          ((DC->iohgatp.MODE == IOHGATP_Sv57x4) && (g_reg_file.capabilities.Sv57x4 == 0))) ) {
+    if ( (iommu->reg_file.fctl.gxl == 0) &&
+         (((DC->iohgatp.MODE == IOHGATP_Sv39x4) && (iommu->reg_file.capabilities.Sv39x4 == 0)) ||
+          ((DC->iohgatp.MODE == IOHGATP_Sv48x4) && (iommu->reg_file.capabilities.Sv48x4 == 0)) ||
+          ((DC->iohgatp.MODE == IOHGATP_Sv57x4) && (iommu->reg_file.capabilities.Sv57x4 == 0))) ) {
         return 1;
     }
     //15. `fctl.GXL` is 1 and `DC.iohgatp.MODE` is not a supported mode
     //    a. `capabilities.Sv32x4` is 0 and `DC.iohgatp.MODE` is `Sv32x4`
-    if ( (g_reg_file.fctl.gxl == 1) &&
-         ((DC->iohgatp.MODE == IOHGATP_Sv32x4) && (g_reg_file.capabilities.Sv32x4 == 0)) ) {
+    if ( (iommu->reg_file.fctl.gxl == 1) &&
+         ((DC->iohgatp.MODE == IOHGATP_Sv32x4) && (iommu->reg_file.capabilities.Sv32x4 == 0)) ) {
         return 1;
     }
     //16. `capabilities.MSI_FLAT` is 1 and `DC.msiptp.MODE` is not `Bare`
     //    and not `Flat`
-    if ( (g_reg_file.capabilities.msi_flat == 1) &&
+    if ( (iommu->reg_file.capabilities.msi_flat == 1) &&
          ((DC->msiptp.MODE != MSIPTP_Off) && (DC->msiptp.MODE != MSIPTP_Flat)) ) {
         return 1;
     }
@@ -329,37 +329,37 @@ do_device_context_configuration_checks(
         return 1;
     }
     //18. `capabilities.AMO` is 0 and `DC.tc.SADE` or `DC.tc.GADE` is 1
-    if ( g_reg_file.capabilities.amo_hwad == 0 && (DC->tc.SADE == 1 || DC->tc.GADE == 1) ) {
+    if ( iommu->reg_file.capabilities.amo_hwad == 0 && (DC->tc.SADE == 1 || DC->tc.GADE == 1) ) {
         return 1;
     }
     //19. `capabilities.END` is 0 and `fctl.be != DC.tc.SBE`
-    if ( g_reg_file.capabilities.end == 0 && (g_reg_file.fctl.be != DC->tc.SBE) ) {
+    if ( iommu->reg_file.capabilities.end == 0 && (iommu->reg_file.fctl.be != DC->tc.SBE) ) {
         return 1;
     }
     //20. `DC.tc.SXL` value is not a legal value. If `fctl.GXL` is 1, then
     //    `DC.tc.SXL` must be 1. If `fctl.GXL` is 0 and is writeable, then
     //    `DC.tc.SXL` may be 0 or 1. If `fctl.GXL` is 0 and is not writeable
     //    then `DC.tc.SXL` must be 0.
-    if ( (g_reg_file.fctl.gxl == 1) && (DC->tc.SXL != 1) ) {
+    if ( (iommu->reg_file.fctl.gxl == 1) && (DC->tc.SXL != 1) ) {
         return 1;
     }
 
-    if ( (g_reg_file.fctl.gxl == 0) && (g_gxl_writeable == 0) && (DC->tc.SXL != 0) ) {
+    if ( (iommu->reg_file.fctl.gxl == 0) && (iommu->gxl_writeable == 0) && (DC->tc.SXL != 0) ) {
         return 1;
     }
 
     //21. `DC.tc.SBE` value is not a legal value. If `fctl.BE` is writeable
     //    then `DC.tc.SBE` may be 0 or 1. If `fctl.BE` is not writeable then
     //    `DC.tc.SBE` must be same as `fctl.BE`.
-    if ( (g_fctl_be_writeable == 0) && (DC->tc.SBE != g_reg_file.fctl.be) ) {
+    if ( (iommu->fctl_be_writeable == 0) && (DC->tc.SBE != iommu->reg_file.fctl.be) ) {
         return 1;
     }
 
     //22. `capabilities.QOSID` is 1 and `DC.ta.RCID` or `DC.ta.MCID` values are wider
     //    than that supported by the IOMMU.
-    if ( (g_reg_file.capabilities.qosid == 1) &&
-         (((DC->ta.rcid & ~g_iommu_qosid_mask.rcid) != 0) ||
-          ((DC->ta.mcid & ~g_iommu_qosid_mask.mcid) != 0)) ) {
+    if ( (iommu->reg_file.capabilities.qosid == 1) &&
+         (((DC->ta.rcid & ~iommu->iommu_qosid_mask.rcid) != 0) ||
+          ((DC->ta.mcid & ~iommu->iommu_qosid_mask.mcid) != 0)) ) {
         return 1;
     }
 

--- a/iommu_ref_model/libiommu/src/iommu_hpm.c
+++ b/iommu_ref_model/libiommu/src/iommu_hpm.c
@@ -5,7 +5,7 @@
 #include "iommu.h"
 void
 count_events(
-    uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
+    iommu_t *iommu, uint8_t PV, uint32_t PID, uint8_t PSCV, uint32_t PSCID,
     uint32_t DID, uint8_t GSCV, uint32_t GSCID, uint16_t eventID) {
     uint8_t i;
     uint32_t mask;
@@ -13,14 +13,14 @@ count_events(
 
     // IOMMU implements a performance-monitoring unit
     // if capabilities.hpm == 1
-    if ( g_reg_file.capabilities.hpm == 0 ) return;
+    if ( iommu->reg_file.capabilities.hpm == 0 ) return;
 
-    for ( i = 0; i < g_num_hpm; i++ ) {
+    for ( i = 0; i < iommu->num_hpm; i++ ) {
         // The performance-monitoring counter inhibits is a 32-bits WARL
         // register where that contains bits to inhibit the corresponding
         // counters from counting. Bit X when set inhibits counting in
         // iohpmctrX and bit 0 inhibits counting in iohpmcycles.
-        if ( g_reg_file.iocountinh.raw & (1UL << i) ) continue;
+        if ( iommu->reg_file.iocountinh.raw & (1UL << i) ) continue;
 
         // Counter is not inhibited check if it matches
         // These performance-monitoring event registers are 64-bit RW
@@ -33,7 +33,7 @@ count_events(
         // device_id based filtering is used, the match may be configured to be
         // a precise match or a partial match. A partial match allows a
         // transactions with a range of IDs to be counted by the counter.
-        if ( g_reg_file.iohpmevt[i].eventID != eventID ) continue;
+        if ( iommu->reg_file.iohpmevt[i].eventID != eventID ) continue;
 
         // When filtering by device_id or GSCID is selected and the event supports
         // ID based filtering, the DMASK field can be used to configure a partial
@@ -47,44 +47,44 @@ count_events(
         // | 1       | yyyyyyyy  yyyyyyyy  yyyyy011 | seg:bus:dev - any func
         // | 1       | yyyyyyyy  yyyyyyyy  01111111 | seg:bus - any dev:func
         // | 1       | yyyyyyyy  01111111  11111111 | seg - any bus:dev:func
-        mask = g_reg_file.iohpmevt[i].did_gscid + 1;
-        mask = mask ^ g_reg_file.iohpmevt[i].did_gscid;
+        mask = iommu->reg_file.iohpmevt[i].did_gscid + 1;
+        mask = mask ^ iommu->reg_file.iohpmevt[i].did_gscid;
         mask = ~mask;
         // If DMASK is 0, then all 24-bits must match
-        mask = (g_reg_file.iohpmevt[i].dmask == 1) ? mask : 0xFFFFFF;
+        mask = (iommu->reg_file.iohpmevt[i].dmask == 1) ? mask : 0xFFFFFF;
 
         // IDT - Filter ID Type: This field indicates the type of ID to
         // filter on.
-        if ( g_reg_file.iohpmevt[i].idt == 0 ) {
+        if ( iommu->reg_file.iohpmevt[i].idt == 0 ) {
             // When 0, the DID_GSCID field holds a device_id and the
             // PID_PSCID field holds a process_id.
-            if ( g_reg_file.iohpmevt[i].pv_pscv == 1 ) {
+            if ( iommu->reg_file.iohpmevt[i].pv_pscv == 1 ) {
                 if ( PV == 0 ) continue;
-                if ( g_reg_file.iohpmevt[i].pid_pscid != PID ) continue;
+                if ( iommu->reg_file.iohpmevt[i].pid_pscid != PID ) continue;
             }
-            if ( g_reg_file.iohpmevt[i].dv_gscv == 1 ) {
-                if ( (g_reg_file.iohpmevt[i].did_gscid & mask) != (DID & mask) ) {
+            if ( iommu->reg_file.iohpmevt[i].dv_gscv == 1 ) {
+                if ( (iommu->reg_file.iohpmevt[i].did_gscid & mask) != (DID & mask) ) {
                     continue;
                 }
             }
         } else {
-            // g_reg_file.iohpmevt[i].idt == 1
+            // iommu->reg_file.iohpmevt[i].idt == 1
             // When 1, the DID_GSCID field holds a GSCID and PID_PSCID
             // field holds a PSCID.
-            if ( g_reg_file.iohpmevt[i].pv_pscv == 1 ) {
+            if ( iommu->reg_file.iohpmevt[i].pv_pscv == 1 ) {
                 if ( PSCV == 0 ) continue;
-                if ( g_reg_file.iohpmevt[i].pid_pscid != PSCID ) continue;
+                if ( iommu->reg_file.iohpmevt[i].pid_pscid != PSCID ) continue;
             }
-            if ( g_reg_file.iohpmevt[i].dv_gscv == 1 ) {
+            if ( iommu->reg_file.iohpmevt[i].dv_gscv == 1 ) {
                 if ( GSCV == 0 ) continue;
-                if ( (g_reg_file.iohpmevt[i].did_gscid & mask) != (GSCID & mask) ) continue;
+                if ( (iommu->reg_file.iohpmevt[i].did_gscid & mask) != (GSCID & mask) ) continue;
             }
         }
         // Counter is not inhibited and all filters pass
-        count = g_reg_file.iohpmctr[i].counter + 1;
-        count = count & ((g_hpmctr_bits == 64) ? -1LL : ((1LL << g_hpmctr_bits) - 1));
-        if ( g_reg_file.iohpmctr[i].counter > count ) {
-            g_reg_file.iohpmctr[i].counter = count;
+        count = iommu->reg_file.iohpmctr[i].counter + 1;
+        count = count & ((iommu->hpmctr_bits == 64) ? -1LL : ((1LL << iommu->hpmctr_bits) - 1));
+        if ( iommu->reg_file.iohpmctr[i].counter > count ) {
+            iommu->reg_file.iohpmctr[i].counter = count;
             // The OF bit is set when the corresponding iohpmctr* overflows,
             // and remains set until cleared by software. Since iohpmctr*
             // values are unsigned values, overflow is defined as unsigned
@@ -97,12 +97,12 @@ count_events(
             // a count overflow interrupt disable for the associated iohpmctr*.
             // A pending HPM Counter Overflow interrupt (OR of all iohpmctr*
             // overflows) is and reported through ipsr register.
-            if ( g_reg_file.iohpmevt[i].of == 0 ) {
-                g_reg_file.iohpmevt[i].of = 1;
-                generate_interrupt(HPM);
+            if ( iommu->reg_file.iohpmevt[i].of == 0 ) {
+                iommu->reg_file.iohpmevt[i].of = 1;
+                generate_interrupt(iommu, HPM);
             }
         } else {
-            g_reg_file.iohpmctr[i].counter = count;
+            iommu->reg_file.iohpmctr[i].counter = count;
         }
     }
     return;

--- a/iommu_ref_model/libiommu/src/iommu_msi_trans.c
+++ b/iommu_ref_model/libiommu/src/iommu_msi_trans.c
@@ -18,14 +18,14 @@ extract(uint64_t data, uint64_t mask) {
 }
 uint8_t
 msi_address_translation(
-    uint64_t gpa, uint8_t is_exec, device_context_t *DC,
+    iommu_t *iommu, uint64_t gpa, uint8_t is_exec, device_context_t *DC,
     uint8_t *is_msi, uint8_t *is_mrif, uint32_t *mrif_nid, uint64_t *dest_mrif_addr,
     uint32_t *cause, uint64_t *iotval2, uint64_t *pa,
     uint64_t *page_sz, gpte_t *g_pte, uint8_t check_access_perms,
     uint32_t rcid, uint32_t mcid) {
 
     uint64_t A, m, I;
-    uint64_t pa_mask = ((1UL << (g_reg_file.capabilities.pas)) - 1);
+    uint64_t pa_mask = ((1UL << (iommu->reg_file.capabilities.pas)) - 1);
     uint8_t status;
     msipte_t msipte;
 
@@ -137,7 +137,7 @@ msi_address_translation(
     //    is as follows:
     //    a. If `capabilities.MSI_MRIF == 0`, stop and report "MSI PTE misconfigured"
     //       (cause = 263).
-    if ( g_reg_file.capabilities.msi_mrif == 0 ) {
+    if ( iommu->reg_file.capabilities.msi_mrif == 0 ) {
         *cause = 263;
         return 1;
     }

--- a/iommu_ref_model/libtables/include/tables_api.h
+++ b/iommu_ref_model/libtables/include/tables_api.h
@@ -5,11 +5,11 @@
 #include "iommu.h"
 #ifndef __TABLES_API_H__
 #define __TABLES_API_H__
-uint64_t add_dev_context(device_context_t *DC, uint32_t device_id);
-uint64_t add_process_context(device_context_t *DC, process_context_t *PC, uint32_t process_id);
-uint64_t add_g_stage_pte(iohgatp_t iohgatp, uint64_t gpa, gpte_t gpte, uint8_t add_level);
+uint64_t add_dev_context(iommu_t *iommu, device_context_t *DC, uint32_t device_id);
+uint64_t add_process_context(iommu_t *iommu, device_context_t *DC, process_context_t *PC, uint32_t process_id);
+uint64_t add_g_stage_pte(iommu_t *iommu, iohgatp_t iohgatp, uint64_t gpa, gpte_t gpte, uint8_t add_level);
 uint64_t add_s_stage_pte(iosatp_t satp, uint64_t va, pte_t pte, uint8_t add_level, uint8_t SXL);
-uint64_t add_vs_stage_pte(iosatp_t satp, uint64_t va, pte_t pte, uint8_t add_level, iohgatp_t iohgatp, uint8_t SXL);
+uint64_t add_vs_stage_pte(iommu_t *iommu, iosatp_t satp, uint64_t va, pte_t pte, uint8_t add_level, iohgatp_t iohgatp, uint8_t SXL);
 uint64_t translate_gpa (iohgatp_t iohgatp, uint64_t gpa, uint64_t *spa);
 
 

--- a/iommu_ref_model/libtables/src/build_ddt.c
+++ b/iommu_ref_model/libtables/src/build_ddt.c
@@ -7,6 +7,7 @@
 
 uint64_t
 add_dev_context(
+    iommu_t *iommu,
     device_context_t *DC, uint32_t device_id) {
     uint64_t a;
     uint8_t i, LEVELS, DC_SIZE;
@@ -16,7 +17,7 @@ add_dev_context(
     // radix-table depending on the maximum width of the device_id supported.
     // The partitioning of the device_id to obtain the device directory indexes
     // (DDI) to traverse the DDT radix-tree table are as follows:
-    if ( g_reg_file.capabilities.msi_flat == 0 ) {
+    if ( iommu->reg_file.capabilities.msi_flat == 0 ) {
         DDI[0] = get_bits(6,   0, device_id);
         DDI[1] = get_bits(15,  7, device_id);
         DDI[2] = get_bits(23, 16, device_id);
@@ -27,10 +28,10 @@ add_dev_context(
         DDI[2] = get_bits(23, 15, device_id);
         DC_SIZE = EXT_FORMAT_DC_SIZE;
     }
-    a = g_reg_file.ddtp.ppn * PAGESIZE;
-    if ( g_reg_file.ddtp.iommu_mode == DDT_3LVL ) LEVELS = 3;
-    if ( g_reg_file.ddtp.iommu_mode == DDT_2LVL ) LEVELS = 2;
-    if ( g_reg_file.ddtp.iommu_mode == DDT_1LVL ) LEVELS = 1;
+    a = iommu->reg_file.ddtp.ppn * PAGESIZE;
+    if ( iommu->reg_file.ddtp.iommu_mode == DDT_3LVL ) LEVELS = 3;
+    if ( iommu->reg_file.ddtp.iommu_mode == DDT_2LVL ) LEVELS = 2;
+    if ( iommu->reg_file.ddtp.iommu_mode == DDT_1LVL ) LEVELS = 1;
     i = LEVELS - 1;
     while ( i > 0 ) {
         ddte.raw = 0;

--- a/iommu_ref_model/libtables/src/build_g_stage_pt.c
+++ b/iommu_ref_model/libtables/src/build_g_stage_pt.c
@@ -6,6 +6,7 @@
 #include "tables_api.h"
 uint64_t
 add_g_stage_pte (
+    iommu_t *iommu,
     iohgatp_t iohgatp, uint64_t gpa, gpte_t gpte, uint8_t add_level) {
 
     uint16_t vpn[5];
@@ -14,13 +15,13 @@ add_g_stage_pte (
     gpte_t nl_gpte;
 
     PTESIZE = 8;
-    if ( iohgatp.MODE == IOHGATP_Sv32x4 && g_reg_file.fctl.gxl == 1 ) {
+    if ( iohgatp.MODE == IOHGATP_Sv32x4 && iommu->reg_file.fctl.gxl == 1 ) {
         vpn[0] = get_bits(21, 12, gpa);
         vpn[1] = get_bits(34, 22, gpa);
         LEVELS = 2;
         PTESIZE = 4;
     }
-    if ( iohgatp.MODE == IOHGATP_Sv39x4 && g_reg_file.fctl.gxl == 0) {
+    if ( iohgatp.MODE == IOHGATP_Sv39x4 && iommu->reg_file.fctl.gxl == 0) {
         vpn[0] = get_bits(20, 12, gpa);
         vpn[1] = get_bits(29, 21, gpa);
         vpn[2] = get_bits(40, 30, gpa);

--- a/iommu_ref_model/libtables/src/build_pdt.c
+++ b/iommu_ref_model/libtables/src/build_pdt.c
@@ -7,6 +7,7 @@
 
 uint64_t
 add_process_context(
+    iommu_t *iommu,
     device_context_t *DC, process_context_t *PC, uint32_t process_id) {
     uint64_t a;
     uint8_t i, LEVELS;
@@ -47,7 +48,7 @@ add_process_context(
                 gpte.PBMT = PMA;
                 gpte.PPN = get_free_ppn(1);
 
-                if ( add_g_stage_pte(DC->iohgatp, (PAGESIZE * pdte.PPN), gpte, 0) == -1 ) return -1;
+                if ( add_g_stage_pte(iommu, DC->iohgatp, (PAGESIZE * pdte.PPN), gpte, 0) == -1 ) return -1;
             } else {
                 pdte.PPN = get_free_ppn(1);
             }

--- a/iommu_ref_model/libtables/src/build_vs_stage_pt.c
+++ b/iommu_ref_model/libtables/src/build_vs_stage_pt.c
@@ -6,6 +6,7 @@
 #include "tables_api.h"
 uint64_t
 add_vs_stage_pte (
+    iommu_t *iommu,
     iosatp_t satp, uint64_t va, pte_t pte, uint8_t add_level,
     iohgatp_t iohgatp, uint8_t SXL) {
 
@@ -66,7 +67,7 @@ add_vs_stage_pte (
             gpte.PBMT = PMA;
             gpte.PPN = get_free_ppn(1);
 
-            if ( add_g_stage_pte(iohgatp, (PAGESIZE * nl_pte.PPN), gpte, 0) == -1) return -1;
+            if ( add_g_stage_pte(iommu, iohgatp, (PAGESIZE * nl_pte.PPN), gpte, 0) == -1) return -1;
 
             if ( write_memory_test((char *)&nl_pte.raw, (a | (vpn[i] * PTESIZE)), PTESIZE) ) return -1;
         }

--- a/iommu_ref_model/test/test_app.c
+++ b/iommu_ref_model/test/test_app.c
@@ -60,6 +60,9 @@ main(void) {
     fqh_t fqh;
     fault_rec_t fault_rec;
 
+    // Create IOMMU instance
+    iommu_t iommu = {0};
+
     // reset system
     fail_if( ( reset_system(1, 2) < 0 ) );
 
@@ -75,70 +78,70 @@ main(void) {
     sv32_bare_sz = 0x200000;
     sv57x4_bare_sz = sv48x4_bare_sz = sv39x4_bare_sz = 0x40000000;
     sv32x4_bare_sz = 0x200000;
-    fail_if( ( reset_iommu(8, 40, 0xff, 3, Off, DDT_3LVL, 0xFFFFFF, 0, 0,
+    fail_if( ( reset_iommu(&iommu, 8, 40, 0xff, 3, Off, DDT_3LVL, 0xFFFFFF, 0, 0,
                            (FILL_IOATC_ATS_T2GPA | FILL_IOATC_ATS_ALWAYS),
                            cap, fctl, sv57_bare_sz, sv48_bare_sz, sv39_bare_sz,
                            sv32_bare_sz, sv57x4_bare_sz, sv48x4_bare_sz, sv39x4_bare_sz,
                            sv32x4_bare_sz) < 0 ) );
     for ( i = MSI_ADDR_0_OFFSET; i <= MSI_ADDR_7_OFFSET; i += 16 ) {
-        write_register(i, 8, 0xFF);
-        fail_if(( read_register(i, 8) != 0xFc ));
-        write_register(i, 8, 0x00);
+        write_register(&iommu, i, 8, 0xFF);
+        fail_if(( read_register(&iommu, i, 8) != 0xFc ));
+        write_register(&iommu, i, 8, 0x00);
     }
     for ( i = MSI_DATA_0_OFFSET; i <= MSI_DATA_7_OFFSET; i += 16 ) {
-        write_register(i, 4, 0);
-        fail_if( ( read_register(i, 4) != 0 ) );
+        write_register(&iommu, i, 4, 0);
+        fail_if( ( read_register(&iommu, i, 4) != 0 ) );
     }
     for ( i = MSI_VEC_CTRL_0_OFFSET; i <= MSI_VEC_CTRL_7_OFFSET; i += 16 ) {
-        write_register(i, 4, 1);
-        fail_if( ( read_register(i, 4) != 1 ) );
+        write_register(&iommu, i, 4, 1);
+        fail_if( ( read_register(&iommu, i, 4) != 1 ) );
     }
     // When Fault queue is not enabled, no logging should occur
     pid_valid = exec_req = priv_req = no_write = 1;
     at = 0;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( ((read_register(FQH_OFFSET, 4)) != read_register(FQT_OFFSET, 4)) ) );
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fail_if( ( ((read_register(&iommu, FQH_OFFSET, 4)) != read_register(&iommu, FQT_OFFSET, 4)) ) );
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqof != 0 ) );
 
     // Enable command queue
-    fail_if( ( enable_cq(4) < 0 ) );
+    fail_if( ( enable_cq(&iommu, 4) < 0 ) );
 
     // Test that writes to cqcsr are discarded when it is busy
-    g_reg_file.cqcsr.busy = 1;
+    iommu.reg_file.cqcsr.busy = 1;
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqen == 0 ) );
     fail_if( ( cqcsr.cqon == 0 ) );
-    g_reg_file.cqcsr.busy = 0;
+    iommu.reg_file.cqcsr.busy = 0;
 
     // Enable fault queue
-    fail_if( ( enable_fq(4) < 0 ) );
+    fail_if( ( enable_fq(&iommu, 4) < 0 ) );
 
     // Test that writes to fqcsr are discarded when it is busy
-    g_reg_file.fqcsr.busy = 1;
+    iommu.reg_file.fqcsr.busy = 1;
     fqcsr.fqen = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqen == 0 ) );
     fail_if( ( fqcsr.fqon == 0 ) );
-    g_reg_file.fqcsr.busy = 0;
+    iommu.reg_file.fqcsr.busy = 0;
 
     // Enable page queue
-    fail_if( ( enable_disable_pq(4, 1) < 0 ) );
+    fail_if( ( enable_disable_pq(&iommu, 4, 1) < 0 ) );
 
     START_TEST("All inbound transactions disallowed");
     FOR_ALL_TRANSACTION_TYPES(at, pid_valid, exec_req, priv_req, no_write, {
         if ( at == ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST ) {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, READ, &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 256, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 256, 0) < 0 ) );
         } else {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 256, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 256, 0) < 0 ) );
         }
     });
     pr.MSGCODE = PAGE_REQ_MSG_CODE;
@@ -161,25 +164,25 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = (0x1234UL << 48UL) | (PRGR_RESPONSE_FAILURE << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(256, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 256, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
     END_TEST();
 
     START_TEST("Bare mode tests");
     // Enable IOMMU in Bare mode
-    fail_if( ( enable_iommu(DDT_Bare) < 0 ) );
+    fail_if( ( enable_iommu(&iommu, DDT_Bare) < 0 ) );
     FOR_ALL_TRANSACTION_TYPES(at, pid_valid, exec_req, priv_req, no_write, {
-        send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+        send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                  priv_req, 0, at, 0xdeadbeef, 16, READ, &req, &rsp);
         if ( at == ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST ) {
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
         }
         if ( at == ADDR_TYPE_TRANSLATED ) {
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
         }
         if ( at == ADDR_TYPE_UNTRANSLATED ) {
-                fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+                fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
         }
     });
     pr.MSGCODE = PAGE_REQ_MSG_CODE;
@@ -202,18 +205,18 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = (0x1234UL << 48UL) | (PRGR_INVALID_REQUEST << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
     // Turn it off
-    fail_if( ( enable_iommu(Off) < 0 ) );
+    fail_if( ( enable_iommu(&iommu, Off) < 0 ) );
     END_TEST();
 
     START_TEST("Too wide device_id");
-    fail_if( ( enable_iommu(DDT_1LVL) < 0 ) );
-    send_translation_request(0x000145, 0, 0x99, 0, 0, 0, 0,
+    fail_if( ( enable_iommu(&iommu, DDT_1LVL) < 0 ) );
+    send_translation_request(&iommu, 0x000145, 0, 0x99, 0, 0, 0, 0,
                              UNTRANSLATED_REQUEST, 0, 1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
     pr.MSGCODE = PAGE_REQ_MSG_CODE;
     pr.TAG = 0;
     pr.RID = 0x1234;
@@ -234,16 +237,16 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = (0x1234UL << 48UL) | (PRGR_INVALID_REQUEST << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
 
-    fail_if( ( enable_iommu(DDT_2LVL) == 0 ) );
-    fail_if( ( enable_iommu(Off) < 0 ) );
-    fail_if( ( enable_iommu(DDT_2LVL) < 0 ) );
-    send_translation_request(0x012345, 0, 0x99, 0, 0, 0, 0,
+    fail_if( ( enable_iommu(&iommu, DDT_2LVL) == 0 ) );
+    fail_if( ( enable_iommu(&iommu, Off) < 0 ) );
+    fail_if( ( enable_iommu(&iommu, DDT_2LVL) < 0 ) );
+    send_translation_request(&iommu, 0x012345, 0, 0x99, 0, 0, 0, 0,
                              UNTRANSLATED_REQUEST, 0, 1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
 
     pr.MSGCODE = PAGE_REQ_MSG_CODE;
     pr.TAG = 0;
@@ -265,12 +268,12 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = (0x1234UL << 48UL) | (PRGR_INVALID_REQUEST << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
 
     // Change to MSI flat mode
-    g_reg_file.capabilities.msi_flat = 0;
+    iommu.reg_file.capabilities.msi_flat = 0;
     pr.MSGCODE = PAGE_REQ_MSG_CODE;
     pr.TAG = 0;
     pr.RID = 0x1234;
@@ -291,68 +294,68 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = (0x1234UL << 48UL) | (PRGR_INVALID_REQUEST << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
-    g_reg_file.capabilities.msi_flat = 1;
+    fail_if( ( check_faults(&iommu, 260, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    iommu.reg_file.capabilities.msi_flat = 1;
 
     END_TEST();
 
     // Enable IOMMU
-    fail_if( ( enable_iommu(Off) < 0 ) );
-    fail_if( ( enable_iommu(DDT_3LVL) < 0 ) );
+    fail_if( ( enable_iommu(&iommu, Off) < 0 ) );
+    fail_if( ( enable_iommu(&iommu, DDT_3LVL) < 0 ) );
 
     START_TEST("Non-leaf DDTE invalid");
     // make DDTE invalid
-    ddtp.raw = read_register(DDTP_OFFSET, 8);
+    ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
     ddte.raw  = 0;
     write_memory_test((char *)&ddte, (ddtp.ppn * PAGESIZE) | (get_bits(23, 15, 0x012345) * 8), 8);
     FOR_ALL_TRANSACTION_TYPES(at, pid_valid, exec_req, priv_req, no_write, {
         if ( at == ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST ) {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, READ, &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
         } else {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
         }
     });
     END_TEST();
 
     START_TEST("NL-DDT access viol & data corruption");
-    iodir(INVAL_DDT, 1, 0x012345, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
     at = ADDR_TYPE_UNTRANSLATED;
     pid_valid = no_write = exec_req = priv_req = 0;
     access_viol_addr = (ddtp.ppn * PAGESIZE) | (get_bits(23, 15, 0x012345) * 8);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 257, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 257, 0) < 0 ) );
     access_viol_addr = -1;
     data_corruption_addr = (ddtp.ppn * PAGESIZE) | (get_bits(23, 15, 0x012345) * 8);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 268, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 268, 0) < 0 ) );
     data_corruption_addr = -1;
     END_TEST();
 
     START_TEST("Non-leaf DDTE reserved bits");
     // Set reserved bits in ddte
     FOR_ALL_TRANSACTION_TYPES(at, pid_valid, exec_req, priv_req, no_write, {
-        ddtp.raw = read_register(DDTP_OFFSET, 8);
+        ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
         ddte.raw  = 0;
         ddte.reserved0 |= no_write;
         ddte.reserved1 |= ~no_write;
         ddte.V = 1;
         write_memory_test((char *)&ddte, (ddtp.ppn * PAGESIZE) | (get_bits(23, 15, 0x012345) * 8), 8);
         if ( at == ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST ) {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, READ, &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
         } else {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
         }
     });
     ddte.raw  = 0;
@@ -362,60 +365,60 @@ main(void) {
 
     START_TEST("Fault queue overflow and memory fault");
     // Clear IPSR
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip == 1 ) );
 
     // Initialize fault queue MSI vector
     // Map fault queue to vector 5
-    write_register(ICVEC_OFFSET, 8, 0x0000000000000050);
+    write_register(&iommu, ICVEC_OFFSET, 8, 0x0000000000000050);
     temp = get_free_ppn(1) * PAGESIZE;
     j = 0;
     write_memory_test((char *)&j, temp, 4);
-    write_register(MSI_ADDR_5_OFFSET, 8, temp);
-    write_register(MSI_DATA_5_OFFSET, 4, 0xDEADBEEF);
-    write_register(MSI_VEC_CTRL_5_OFFSET, 4, 0);
-    write_register(IPSR_OFFSET, 4, read_register(IPSR_OFFSET, 4));
+    write_register(&iommu, MSI_ADDR_5_OFFSET, 8, temp);
+    write_register(&iommu, MSI_DATA_5_OFFSET, 4, 0xDEADBEEF);
+    write_register(&iommu, MSI_VEC_CTRL_5_OFFSET, 4, 0);
+    write_register(&iommu, IPSR_OFFSET, 4, read_register(&iommu, IPSR_OFFSET, 4));
 
     // Trigger a fault queue overflow
     // The queue should be empty now
-    fail_if( ( (read_register(FQH_OFFSET, 4) != read_register(FQT_OFFSET, 4)) ) );
+    fail_if( ( (read_register(&iommu, FQH_OFFSET, 4) != read_register(&iommu, FQT_OFFSET, 4)) ) );
     // Force the head and tail to 0
-    g_reg_file.fqh.index = 0;
-    g_reg_file.fqt.index = 0;
-    fqb.raw = read_register(FQB_OFFSET, 8);
+    iommu.reg_file.fqh.index = 0;
+    iommu.reg_file.fqt.index = 0;
+    fqb.raw = read_register(&iommu, FQB_OFFSET, 8);
     pid_valid = exec_req = priv_req = no_write = 1;
     at = 0;
     for ( i = 0; i < 1023; i++ ) {
-        send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+        send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                  priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
     }
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip == 0 ) );
     read_memory_test(temp, 4, (char *)&j);
     fail_if( ( j != 0xDEADBEEF ) );
     j = 0;
     write_memory_test((char *)&j, temp, 4);
     // Clear IPSR
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 0 ) );
 
     // The queue should be be full
-    fail_if( (((read_register(FQT_OFFSET, 4) + 1) & ((1UL << (fqb.log2szm1 + 1)) - 1)) !=
-                read_register(FQH_OFFSET, 4)) );
+    fail_if( (((read_register(&iommu, FQT_OFFSET, 4) + 1) & ((1UL << (fqb.log2szm1 + 1)) - 1)) !=
+                read_register(&iommu, FQH_OFFSET, 4)) );
     // No overflow should be set
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqof == 1 ) );
     // Next fault should cause overflow
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( (((read_register(FQT_OFFSET, 4) + 1) & ((1UL << (fqb.log2szm1 + 1)) - 1)) !=
-                read_register(FQH_OFFSET, 4)) );
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fail_if( (((read_register(&iommu, FQT_OFFSET, 4) + 1) & ((1UL << (fqb.log2szm1 + 1)) - 1)) !=
+                read_register(&iommu, FQH_OFFSET, 4)) );
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqof == 0 ) );
 
     // Overflow should have triggered a MSI
@@ -423,12 +426,12 @@ main(void) {
     fail_if( ( j != 0xDEADBEEF ) );
     j = 0;
     write_memory_test((char *)&j, temp, 4);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
     // Clear IPSR
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
     // Should retrigger since fqof is still set
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
     read_memory_test(temp, 4, (char *)&j);
     fail_if( ( j != 0xDEADBEEF ) );
@@ -436,91 +439,91 @@ main(void) {
     write_memory_test((char *)&j, temp, 4);
 
     // Overflow should remain
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( (((read_register(FQT_OFFSET, 4) + 1) & ((1UL << (fqb.log2szm1 + 1)) - 1)) !=
-                read_register(FQH_OFFSET, 4)) );
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fail_if( (((read_register(&iommu, FQT_OFFSET, 4) + 1) & ((1UL << (fqb.log2szm1 + 1)) - 1)) !=
+                read_register(&iommu, FQH_OFFSET, 4)) );
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqof == 0 ) );
 
     // disable and re-enable fault queue
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fqcsr.fqen = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    write_register(FQH_OFFSET, 4, 0);
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQH_OFFSET, 4, 0);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( (fqcsr.fqen == 1) );
     fail_if( (fqcsr.fqon == 1) );
     fail_if( (fqcsr.busy == 1) );
 
     // Clear IPSR
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 0 ) );
 
     fqcsr.fqen = 1;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( (fqcsr.fqen == 0) );
     fail_if( (fqcsr.fqon == 0) );
     fail_if( (fqcsr.busy == 1) );
     fail_if( (fqcsr.fqmf == 1) );
     fail_if( (fqcsr.fqof == 1) );
-    fail_if( ( ((read_register(FQH_OFFSET, 4)) != read_register(FQT_OFFSET, 4)) ) );
-    fail_if( ( (read_register(FQH_OFFSET, 4) != 0) ) );
+    fail_if( ( ((read_register(&iommu, FQH_OFFSET, 4)) != read_register(&iommu, FQT_OFFSET, 4)) ) );
+    fail_if( ( (read_register(&iommu, FQH_OFFSET, 4) != 0) ) );
 
     // Create a memory fault
-    fqb.raw = read_register(FQB_OFFSET, 8);
+    fqb.raw = read_register(&iommu, FQB_OFFSET, 8);
     access_viol_addr = fqb.ppn * PAGESIZE;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( read_register(FQH_OFFSET, 4) != read_register(FQT_OFFSET, 4) ) );
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fail_if( ( read_register(&iommu, FQH_OFFSET, 4) != read_register(&iommu, FQT_OFFSET, 4) ) );
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqmf != 1 ) );
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( read_register(FQH_OFFSET, 4) != read_register(FQT_OFFSET, 4) ) );
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fail_if( ( read_register(&iommu, FQH_OFFSET, 4) != read_register(&iommu, FQT_OFFSET, 4) ) );
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqmf == 1 ) );
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 0 ) );
 
     // Memory fault with interrupts inhibited
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fqcsr.fie = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqmf != 1 ) );
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip == 1 ) );
     fqcsr.fie = 1;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
 
     access_viol_addr = -1;
     fqcsr.fqen = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
     fqcsr.fqen = 1;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
     // memory fault on MSI write
     access_viol_addr = temp;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+    fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
     fail_if( ( fqcsr.fqmf != 0 ) );
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.fip != 1 ) );
-    fqh.raw = read_register(FQH_OFFSET, 4);
-    fqb.raw = read_register(FQB_OFFSET, 8);
+    fqh.raw = read_register(&iommu, FQH_OFFSET, 4);
+    fqb.raw = read_register(&iommu, FQB_OFFSET, 8);
     read_memory_test(((fqb.ppn * PAGESIZE) | ((fqh.index + 1) * 32)), 32, (char *)&fault_rec);
     fail_if( ( fault_rec.TTYP != 0 ) );
     fail_if( ( fault_rec.iotval != temp ) );
@@ -531,16 +534,16 @@ main(void) {
     fail_if( ( fault_rec.PRIV != 0 ) );
     access_viol_addr = -1;
     fqcsr.fqen = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
     fqcsr.fqen = 1;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
 
     END_TEST();
 
     START_TEST("Device context invalid");
 
     // Add a device 0x012345 to guest with GSCID=1
-    DC_addr = add_device(0x012345, 1, 0, 0, 0, 0, 0,
+    DC_addr = add_device(&iommu, 0x012345, 1, 0, 0, 0, 0, 0,
                          1, 1, 0, 0, 0,
                          IOHGATP_Sv48x4, IOSATP_Bare, PDTP_Bare,
                          MSIPTP_Flat, 1, 0xFFFFFFFFFF, 0x1000000000);
@@ -552,13 +555,13 @@ main(void) {
     write_memory_test((char *)&DC, DC_addr, 64);
     FOR_ALL_TRANSACTION_TYPES(at, pid_valid, exec_req, priv_req, no_write, {
         if ( at == ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST ) {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, READ, &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
         } else {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
         }
     });
     DC.tc.V = 1;
@@ -571,220 +574,220 @@ main(void) {
     pid_valid = no_write = exec_req = priv_req = 0;
     DC.reserved = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.reserved = 0;
 
     DC.tc.reserved0 = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.reserved0 = 0;
 
     DC.tc.reserved1 = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.reserved1 = 0;
 
     DC.tc.reserved0 = 1;
     DC.tc.reserved1 = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.reserved0 = 0;
     DC.tc.reserved1 = 0;
 
     DC.ta.reserved0 = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.ta.reserved0 = 0;
     DC.ta.reserved1 = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.ta.reserved1 = 0;
     DC.fsc.iosatp.reserved = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.fsc.iosatp.reserved = 0;
     DC.msiptp.reserved = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.msiptp.reserved = 0;
     DC.msi_addr_mask.reserved = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.msi_addr_mask.reserved = 0;
     DC.msi_addr_pattern.reserved = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.msi_addr_pattern.reserved = 0;
-    g_reg_file.fctl.gxl = 1;
+    iommu.reg_file.fctl.gxl = 1;
     DC.iohgatp.MODE = IOHGATP_Sv32x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.fctl.gxl = 0;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.fctl.gxl = 0;
     DC.iohgatp.MODE = IOHGATP_Sv48x4;
     DC.iohgatp.MODE = IOHGATP_Sv57x4 + 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.iohgatp.MODE = IOHGATP_Sv48x4;
-    g_reg_file.fctl.gxl = 1;
+    iommu.reg_file.fctl.gxl = 1;
     DC.fsc.iosatp.MODE = IOSATP_Sv32;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.fctl.gxl = 0;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.fctl.gxl = 0;
     DC.fsc.iosatp.MODE = IOSATP_Bare;
     DC.fsc.iosatp.MODE = IOSATP_Sv57 + 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.fsc.iosatp.MODE = IOSATP_Bare;
     DC.msiptp.MODE = MSIPTP_Flat + 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.msiptp.MODE = MSIPTP_Off;
     DC.tc.T2GPA = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.T2GPA = 0;
     DC.tc.EN_PRI = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.EN_PRI = 0;
     DC.tc.PRPR = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.PRPR = 0;
     DC.tc.PDTV = 1;
     DC.fsc.pdtp.MODE = PD20 + 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.fsc.pdtp.MODE = PDTP_Bare;
     DC.fsc.pdtp.reserved = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.fsc.pdtp.reserved = 0;
     DC.tc.PDTV = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
 
     DC.iohgatp.PPN |= 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.iohgatp.PPN |= 2;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.iohgatp.PPN &= ~0x3;
     write_memory_test((char *)&DC, DC_addr, 64);
 
-    g_reg_file.capabilities.amo_hwad = 0;
+    iommu.reg_file.capabilities.amo_hwad = 0;
     DC.tc.SADE = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.SADE = 0;
     DC.tc.GADE = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.SADE = 1;
     DC.tc.GADE = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.SADE = 0;
     DC.tc.GADE = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.amo_hwad = 1;
+    iommu.reg_file.capabilities.amo_hwad = 1;
 
-    g_reg_file.capabilities.ats = 0;
+    iommu.reg_file.capabilities.ats = 0;
     DC.tc.EN_ATS = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.EN_ATS = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
 
     DC.tc.EN_PRI = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.EN_PRI = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
 
     DC.tc.PRPR = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.PRPR = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.ats = 1;
+    iommu.reg_file.capabilities.ats = 1;
 
-    g_reg_file.capabilities.t2gpa = 0;
+    iommu.reg_file.capabilities.t2gpa = 0;
     DC.tc.T2GPA = 1;
     DC.tc.EN_ATS = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.T2GPA = 0;
     DC.tc.EN_ATS = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.t2gpa = 1;
+    iommu.reg_file.capabilities.t2gpa = 1;
 
     DC.tc.T2GPA = 1;
     DC.tc.EN_ATS = 1;
     temp = DC.iohgatp.MODE;
     DC.iohgatp.MODE = IOHGATP_Bare;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.T2GPA = 0;
     DC.tc.EN_ATS = 0;
     DC.iohgatp.MODE = temp;
@@ -793,29 +796,29 @@ main(void) {
     DC.tc.PDTV = 1;
     temp = DC.fsc.pdtp.MODE;
 
-    g_reg_file.capabilities.pd20 = 0;
+    iommu.reg_file.capabilities.pd20 = 0;
     DC.fsc.pdtp.MODE = PD20;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.capabilities.pd20 = 1;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.capabilities.pd20 = 1;
 
-    g_reg_file.capabilities.pd17 = 0;
+    iommu.reg_file.capabilities.pd17 = 0;
     DC.fsc.pdtp.MODE = PD17;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.capabilities.pd17 = 1;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.capabilities.pd17 = 1;
 
-    g_reg_file.capabilities.pd8 = 0;
+    iommu.reg_file.capabilities.pd8 = 0;
     DC.fsc.pdtp.MODE = PD8;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.capabilities.pd8 = 1;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.capabilities.pd8 = 1;
     DC.tc.PDTV = 0;
     DC.fsc.pdtp.MODE = temp;
     write_memory_test((char *)&DC, DC_addr, 64);
@@ -825,51 +828,51 @@ main(void) {
     temp = DC.fsc.iosatp.MODE;
     DC.fsc.iosatp.MODE = IOSATP_Sv48;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.SXL = 0;
     DC.fsc.iosatp.MODE = temp;
     write_memory_test((char *)&DC, DC_addr, 64);
 
     temp = DC.fsc.iosatp.MODE;
 
-    g_reg_file.capabilities.Sv39 = 0;
+    iommu.reg_file.capabilities.Sv39 = 0;
     DC.fsc.iosatp.MODE = IOSATP_Sv39;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv39 = 1;
+    iommu.reg_file.capabilities.Sv39 = 1;
 
-    g_reg_file.capabilities.Sv48 = 0;
+    iommu.reg_file.capabilities.Sv48 = 0;
     DC.fsc.iosatp.MODE = IOSATP_Sv48;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv48 = 1;
+    iommu.reg_file.capabilities.Sv48 = 1;
 
-    g_reg_file.capabilities.Sv57 = 0;
+    iommu.reg_file.capabilities.Sv57 = 0;
     DC.fsc.iosatp.MODE = IOSATP_Sv57;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv57 = 1;
+    iommu.reg_file.capabilities.Sv57 = 1;
 
 
     DC.tc.SXL = 1;
     DC.fsc.iosatp.MODE = IOSATP_Sv32;
-    g_reg_file.capabilities.Sv32 = 0;
+    iommu.reg_file.capabilities.Sv32 = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.capabilities.Sv32 = 1;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.capabilities.Sv32 = 1;
     DC.tc.SXL = 0;
 
     DC.fsc.iosatp.MODE = temp;
@@ -877,85 +880,85 @@ main(void) {
 
     DC.tc.DPE = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.tc.DPE = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
 
-    g_reg_file.fctl.gxl = 1;
+    iommu.reg_file.fctl.gxl = 1;
     temp = DC.iohgatp.MODE;
     DC.iohgatp.MODE = IOHGATP_Sv39x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
 
 
     DC.iohgatp.MODE = IOHGATP_Sv32x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv32x4 = 0;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    iommu.reg_file.capabilities.Sv32x4 = 0;
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
 
     DC.iohgatp.MODE = temp;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv32x4 = 1;
-    g_reg_file.fctl.gxl = 0;
+    iommu.reg_file.capabilities.Sv32x4 = 1;
+    iommu.reg_file.fctl.gxl = 0;
 
 
     temp = DC.iohgatp.MODE;
-    g_reg_file.capabilities.Sv39x4 = 0;
+    iommu.reg_file.capabilities.Sv39x4 = 0;
     DC.iohgatp.MODE = IOHGATP_Sv39x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv39x4 = 1;
+    iommu.reg_file.capabilities.Sv39x4 = 1;
 
-    g_reg_file.capabilities.Sv48x4 = 0;
+    iommu.reg_file.capabilities.Sv48x4 = 0;
     DC.iohgatp.MODE = IOHGATP_Sv48x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv48x4 = 1;
+    iommu.reg_file.capabilities.Sv48x4 = 1;
 
-    g_reg_file.capabilities.Sv57x4 = 0;
+    iommu.reg_file.capabilities.Sv57x4 = 0;
     DC.iohgatp.MODE = IOHGATP_Sv57x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.iohgatp.MODE = temp;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.Sv57x4 = 1;
+    iommu.reg_file.capabilities.Sv57x4 = 1;
 
 
-    g_reg_file.capabilities.end = 0;
-    g_reg_file.fctl.be = 0;
+    iommu.reg_file.capabilities.end = 0;
+    iommu.reg_file.fctl.be = 0;
     DC.tc.SBE = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
 
-    g_reg_file.capabilities.end = 0;
-    g_reg_file.fctl.be = 0;
+    iommu.reg_file.capabilities.end = 0;
+    iommu.reg_file.fctl.be = 0;
     DC.tc.SBE = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
 
-    g_reg_file.fctl.gxl = 1;
+    iommu.reg_file.fctl.gxl = 1;
     temp = DC.iohgatp.MODE;
     DC.iohgatp.MODE = IOHGATP_Sv32x4;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.fctl.gxl = 0;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.fctl.gxl = 0;
     DC.iohgatp.MODE = temp;
     write_memory_test((char *)&DC, DC_addr, 64);
 
@@ -963,54 +966,54 @@ main(void) {
     temp = DC.fsc.iosatp.MODE;
     DC.fsc.iosatp.MODE = IOSATP_Sv32;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.fsc.iosatp.MODE = temp;
     DC.tc.SXL = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
 
-    g_reg_file.fctl.be = 1;
-    g_reg_file.capabilities.end = 1;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    iommu.reg_file.fctl.be = 1;
+    iommu.reg_file.capabilities.end = 1;
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
-    g_reg_file.fctl.be = 0;
-    g_reg_file.capabilities.end = 0;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    iommu.reg_file.fctl.be = 0;
+    iommu.reg_file.capabilities.end = 0;
 
     temp = DC.iohgatp.MODE;
     temp1 = DC.msiptp.MODE;
     DC.iohgatp.MODE = IOHGATP_Bare;
     DC.msiptp.MODE = MSIPTP_Flat;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.iohgatp.MODE = temp;
     DC.msiptp.MODE = temp1;
     write_memory_test((char *)&DC, DC_addr, 64);
 
-    g_reg_file.capabilities.qosid = 1;
-    g_iommu_qosid_mask.rcid = 0x3;
-    g_iommu_qosid_mask.mcid = 0x3;
+    iommu.reg_file.capabilities.qosid = 1;
+    iommu.iommu_qosid_mask.rcid = 0x3;
+    iommu.iommu_qosid_mask.mcid = 0x3;
     DC.ta.rcid = 0x7;
     DC.ta.mcid = 0x3;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.ta.rcid = 0x3;
     DC.ta.mcid = 0x7;
     write_memory_test((char *)&DC, DC_addr, 64);
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.ta.rcid = 0x0;
     DC.ta.mcid = 0x0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    g_reg_file.capabilities.qosid = 0;
+    iommu.reg_file.capabilities.qosid = 0;
 
-    iodir(INVAL_DDT, 1, 0x012345, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
 
 
     END_TEST();
@@ -1018,16 +1021,16 @@ main(void) {
     START_TEST("Unsupported transaction type");
     FOR_ALL_TRANSACTION_TYPES(at, pid_valid, exec_req, priv_req, no_write, {
         if ( at == ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST ) {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, READ, &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
         } else if ( at == ADDR_TYPE_TRANSLATED ) {
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
         } else {
             uint16_t exp_cause;
-            send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+            send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                                      priv_req, 0, at, 0xdeadbeef, 16, (no_write ^ 1), &req, &rsp);
             if ( pid_valid == 1 ) exp_cause = 260;
             else if ( (no_write ^ 1) == WRITE ) exp_cause = 23;
@@ -1035,7 +1038,7 @@ main(void) {
             else exp_cause = 21;
             exp_iotval2 = ( exp_cause != 260) ? 0xdeadbeec : 0;
             // iotval2 reports the gpa i.e. the iova
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, exp_cause, exp_iotval2) < 0 )
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, exp_cause, exp_iotval2) < 0 )
                 );
         }
     });
@@ -1043,18 +1046,18 @@ main(void) {
 
 
     START_TEST("Dev. ctx. access viol & data corruption");
-    iodir(INVAL_DDT, 1, 0x012345, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
     at = ADDR_TYPE_UNTRANSLATED;
     pid_valid = no_write = exec_req = priv_req = 0;
     access_viol_addr = DC_addr;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 257, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 257, 0) < 0 ) );
     access_viol_addr = -1;
     data_corruption_addr = DC_addr;
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 268, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 268, 0) < 0 ) );
     data_corruption_addr = -1;
     END_TEST();
 
@@ -1063,22 +1066,22 @@ main(void) {
     at = ADDR_TYPE_UNTRANSLATED;
     pid_valid = no_write = exec_req = priv_req = 0;
     // Get the device context cached
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, 0xdeadbeec) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, 0xdeadbeec) < 0 ) );
     // Update memory to mark invalid
     DC.tc.V = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
     // Cached copy should apply
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, 0xdeadbeec) < 0 ) );
-    iodir(INVAL_DDT, 1, 0x012345, 0);
-    fail_if( ( read_register(CQH_OFFSET, 4) != read_register(CQT_OFFSET, 4) ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, 0xdeadbeec) < 0 ) );
+    iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
+    fail_if( ( read_register(&iommu, CQH_OFFSET, 4) != read_register(&iommu, CQT_OFFSET, 4) ) );
     // Memory copy should apply
-    send_translation_request(0x012345, pid_valid, 0x99, no_write, exec_req,
+    send_translation_request(&iommu, 0x012345, pid_valid, 0x99, no_write, exec_req,
                              priv_req, 0, at, 0xdeadbeef, 16, (no_write ^1), &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 258, 0) < 0 ) );
     DC.tc.V = 1;
     DC.tc.EN_ATS = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
@@ -1093,7 +1096,7 @@ main(void) {
                 write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
                 pr_go_requested = 0;
                 pw_go_requested = 0;
-                iofence(IOFENCE_C, PR, PW, AV, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+                iofence(&iommu, IOFENCE_C, PR, PW, AV, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
                 read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
                 fail_if( ( AV == 1 && iofence_data != 0x12345678DEADBEEF )  );
                 fail_if( ( AV == 0 && iofence_data != 0x1234567812345678 )  );
@@ -1108,31 +1111,31 @@ main(void) {
     pw_go_requested = 0;
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
 
-    iofence(IOFENCE_C+1, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C+1, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( 0 != pr_go_requested ) );
 
     // Queue another - since illegal is set, head should not move
-    iofence(IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 2) != read_register(CQT_OFFSET, 4) ) );
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 2) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( 0 != pr_go_requested ) );
 
     // fix the illegal commend
-    cqb.raw = read_register(CQB_OFFSET, 8);
-    cqh.raw = read_register(CQH_OFFSET, 4);
+    cqb.raw = read_register(&iommu, CQB_OFFSET, 8);
+    cqh.raw = read_register(&iommu, CQH_OFFSET, 4);
     read_memory_test(((cqb.ppn * PAGESIZE) | (cqh.index * 16)), 16, (char *)&cmd);
     cmd.iofence.func3 = IOFENCE_C;
     write_memory_test((char *)&cmd, ((cqb.ppn * PAGESIZE) | (cqh.index * 16)), 16);
 
     // Clear the illegal
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    process_commands();
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 1) != read_register(CQT_OFFSET, 4) ) );
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    process_commands(&iommu);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 1) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678DEADBEEF )  );
     fail_if( ( 1 != pr_go_requested ) );
@@ -1141,8 +1144,8 @@ main(void) {
     pr_go_requested = 0;
     pw_go_requested = 0;
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
-    process_commands();
-    fail_if( ( (read_register(CQH_OFFSET, 4)) != read_register(CQT_OFFSET, 4) ) );
+    process_commands(&iommu);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4)) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678DEADBEEF )  );
     fail_if( ( 1 != pr_go_requested ) );
@@ -1153,23 +1156,23 @@ main(void) {
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
 
     // Set WSI - not supported in this config
-    iofence(IOFENCE_C, 1, 0, 1, 1, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 1, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( 0 != pr_go_requested ) );
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 1) != read_register(CQT_OFFSET, 4) ) );
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 1) != read_register(&iommu, CQT_OFFSET, 4) ) );
     // Clear the illegal
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
     // fix the illegal commend
-    cqb.raw = read_register(CQB_OFFSET, 8);
-    cqh.raw = read_register(CQH_OFFSET, 4);
+    cqb.raw = read_register(&iommu, CQB_OFFSET, 8);
+    cqh.raw = read_register(&iommu, CQH_OFFSET, 4);
     read_memory_test(((cqb.ppn * PAGESIZE) | (cqh.index * 16)), 16, (char *)&cmd);
     cmd.iofence.wsi = 0;
     write_memory_test((char *)&cmd, ((cqb.ppn * PAGESIZE) | (cqh.index * 16)), 16);
-    process_commands();
-    fail_if( ( (read_register(CQH_OFFSET, 4)) != read_register(CQT_OFFSET, 4) ) );
+    process_commands(&iommu);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4)) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678DEADBEEF )  );
     fail_if( ( 1 != pr_go_requested ) );
@@ -1180,35 +1183,35 @@ main(void) {
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
 
     // Cause command queue memory fault
-    cqb.raw = read_register(CQB_OFFSET, 8);
-    cqt.raw = read_register(CQT_OFFSET, 4);
+    cqb.raw = read_register(&iommu, CQB_OFFSET, 8);
+    cqt.raw = read_register(&iommu, CQT_OFFSET, 4);
     access_viol_addr = ((cqb.ppn * PAGESIZE) | (cqt.index * 16));
 
-    iofence(IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqmf != 1 ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( 0 != pr_go_requested ) );
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 1) != read_register(CQT_OFFSET, 4) ) );
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 1) != read_register(&iommu, CQT_OFFSET, 4) ) );
 
     // Queue another - since cqmf is set, head should not move
-    iofence(IOFENCE_C, 0, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE2);
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 2) != read_register(CQT_OFFSET, 4) ) );
+    iofence(&iommu, IOFENCE_C, 0, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE2);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 2) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( 0 != pr_go_requested ) );
     // Clear the cqmf
     access_viol_addr = -1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    process_commands();
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 1) != read_register(CQT_OFFSET, 4) ) );
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    process_commands(&iommu);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 1) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678DEADBEE1 )  );
     fail_if( ( 1 != pr_go_requested ) );
     fail_if( ( 0 != pw_go_requested ) );
-    process_commands();
-    fail_if( ( (read_register(CQH_OFFSET, 4)) != read_register(CQT_OFFSET, 4) ) );
+    process_commands(&iommu);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4)) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678DEADBEE2 )  );
     fail_if( ( 0 != pr_go_requested ) );
@@ -1222,18 +1225,18 @@ main(void) {
     // Cause memory fault on completion buffer
     access_viol_addr = iofence_PPN * PAGESIZE;
 
-    iofence(IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqmf != 1 ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 1) != read_register(CQT_OFFSET, 4) ) );
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 1) != read_register(&iommu, CQT_OFFSET, 4) ) );
 
     // Clear the cqmf
     access_viol_addr = -1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    process_commands();
-    fail_if( ( (read_register(CQH_OFFSET, 4) ) != read_register(CQT_OFFSET, 4) ) );
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    process_commands(&iommu);
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) ) != read_register(&iommu, CQT_OFFSET, 4) ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678DEADBEE1 )  );
 
@@ -1244,22 +1247,22 @@ main(void) {
 
     // Cause memory fault on completion buffer
     access_viol_addr = iofence_PPN * PAGESIZE;
-    iofence(IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqmf != 1 ) );
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
-    fail_if( ( (read_register(CQH_OFFSET, 4) + 1) != read_register(CQT_OFFSET, 4) ) );
+    fail_if( ( (read_register(&iommu, CQH_OFFSET, 4) + 1) != read_register(&iommu, CQT_OFFSET, 4) ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqen == 1 ) );
     fail_if( ( cqcsr.cqon == 1 ) );
     fail_if( ( cqcsr.busy == 1 ) );
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqen == 0 ) );
     fail_if( ( cqcsr.cqon == 0 ) );
     fail_if( ( cqcsr.cqmf == 1 ) );
@@ -1268,101 +1271,101 @@ main(void) {
     fail_if( ( cqcsr.cmd_to == 1 ) );
 
     // DIsable CQ interrupts
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
     cqcsr.cie = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
     access_viol_addr = iofence_PPN * PAGESIZE;
-    iofence(IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqmf != 1 ) );
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.cip != 0 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
     cqcsr.cie = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
 
     access_viol_addr = -1;
 
     // Test fence_w_ip
-    g_reg_file.capabilities.igs = IGS_BOTH;
-    ddtp.raw = read_register(DDTP_OFFSET, 8);
+    iommu.reg_file.capabilities.igs = IGS_BOTH;
+    ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
     ddtp.iommu_mode = Off;
-    write_register(DDTP_OFFSET, 8, ddtp.raw);
+    write_register(&iommu, DDTP_OFFSET, 8, ddtp.raw);
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     fqcsr.fqen = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    write_register(FQH_OFFSET, 4, 0);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQH_OFFSET, 4, 0);
     pqcsr.pqen = 0;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    write_register(PQH_OFFSET, 4, 0);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    write_register(&iommu, PQH_OFFSET, 4, 0);
 
-    fctl.raw = read_register(FCTRL_OFFSET, 4);
+    fctl.raw = read_register(&iommu, FCTRL_OFFSET, 4);
     fctl.wsi = 1;
-    write_register(FCTRL_OFFSET, 4, fctl.raw);
-    fctl.raw = read_register(FCTRL_OFFSET, 4);
+    write_register(&iommu, FCTRL_OFFSET, 4, fctl.raw);
+    fctl.raw = read_register(&iommu, FCTRL_OFFSET, 4);
     fail_if( (fctl.wsi == 0) );
 
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
     fqcsr.fqen = 1;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
     pqcsr.pqen = 1;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    ddtp.raw = read_register(DDTP_OFFSET, 8);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
     ddtp.iommu_mode = DDT_3LVL;
-    write_register(DDTP_OFFSET, 8, ddtp.raw);
+    write_register(&iommu, DDTP_OFFSET, 8, ddtp.raw);
 
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( (ipsr.cip == 1) );
 
-    iofence(IOFENCE_C, 1, 0, 1, 1, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    iofence(&iommu, IOFENCE_C, 1, 0, 1, 1, (iofence_PPN * PAGESIZE), 0xDEADBEE1);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( (cqcsr.fence_w_ip == 0) );
     fail_if( (ipsr.cip == 0) );
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( (ipsr.cip == 0) );
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(IPSR_OFFSET, 4, ipsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, IPSR_OFFSET, 4, ipsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( (cqcsr.fence_w_ip == 1) );
     fail_if( (ipsr.cip == 1) );
 
-    ddtp.raw = read_register(DDTP_OFFSET, 8);
+    ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
     ddtp.iommu_mode = Off;
-    write_register(DDTP_OFFSET, 8, ddtp.raw);
+    write_register(&iommu, DDTP_OFFSET, 8, ddtp.raw);
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     fqcsr.fqen = 0;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-    write_register(FQH_OFFSET, 4, 0);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQH_OFFSET, 4, 0);
     pqcsr.pqen = 0;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    write_register(PQH_OFFSET, 4, 0);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    write_register(&iommu, PQH_OFFSET, 4, 0);
 
     fctl.wsi = 0;
-    write_register(FCTRL_OFFSET, 4, fctl.raw);
+    write_register(&iommu, FCTRL_OFFSET, 4, fctl.raw);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
     fqcsr.fqen = 1;
-    write_register(FQCSR_OFFSET, 4, fqcsr.raw);
+    write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
     pqcsr.pqen = 1;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    ddtp.raw = read_register(DDTP_OFFSET, 8);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
     ddtp.iommu_mode = DDT_3LVL;
-    write_register(DDTP_OFFSET, 8, ddtp.raw);
-    g_reg_file.capabilities.igs = MSI;
+    write_register(&iommu, DDTP_OFFSET, 8, ddtp.raw);
+    iommu.reg_file.capabilities.igs = MSI;
 
     END_TEST();
 
@@ -1399,8 +1402,8 @@ main(void) {
             gpa = 512UL * 512UL * PAGESIZE;
         }
         write_memory_test((char *)&DC, DC_addr, 64);
-        iodir(INVAL_DDT, 1, 0x012345, 0);
-        iotinval(GVMA, 1, 0, 0, DC.iohgatp.GSCID, 0, 0);
+        iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
+        iotinval(&iommu, GVMA, 1, 0, 0, DC.iohgatp.GSCID, 0, 0);
         for ( i = 0; i < 5; i++ ) {
             if ( (i == 4) && DC.iohgatp.MODE != IOHGATP_Sv57x4 ) continue;
             if ( (i == 3) && DC.iohgatp.MODE != IOHGATP_Sv48x4 &&
@@ -1409,8 +1412,8 @@ main(void) {
             req.tr.iova = gpa;
             gpte.PPN = 512UL * 512UL * 512UL * 512UL;
             gpte.PPN |= (1UL << (i * 9UL));
-            pte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, i);
-            iommu_translate_iova(&req, &rsp);
+            pte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, i);
+            iommu_translate_iova(&iommu, &req, &rsp);
             fail_if( ( rsp.status != SUCCESS ) );
             fail_if( ( rsp.trsp.S == 1 && i == 0 ) );
             fail_if( ( rsp.trsp.S == 0 && i != 0 ) );
@@ -1438,8 +1441,8 @@ main(void) {
                 gpte.W = 0;
                 gpte.R = 0;
                 write_memory_test((char *)&gpte, pte_addr, 8);
-                iotinval(GVMA, 0, 0, 0, 0, 0, 0);
-                iommu_translate_iova(&req, &rsp);
+                iotinval(&iommu, GVMA, 0, 0, 0, 0, 0, 0);
+                iommu_translate_iova(&iommu, &req, &rsp);
                 fail_if( ( rsp.status != SUCCESS ) );
                 fail_if( ( rsp.trsp.R != 0 ) );
                 fail_if( ( rsp.trsp.W != 0 ) );
@@ -1447,28 +1450,28 @@ main(void) {
                 gpte.W = 1;
                 gpte.R = 1;
                 write_memory_test((char *)&gpte, pte_addr, 8);
-                iotinval(GVMA, 0, 0, 0, 0, 0, 0);
+                iotinval(&iommu, GVMA, 0, 0, 0, 0, 0, 0);
             }
         }
     }
-    g_reg_file.capabilities.Sv57x4 = 0;
-    g_reg_file.capabilities.Sv48x4 = 0;
-    g_reg_file.capabilities.Sv39x4 = 0;
-    g_reg_file.capabilities.Sv32x4 = 0;
+    iommu.reg_file.capabilities.Sv57x4 = 0;
+    iommu.reg_file.capabilities.Sv48x4 = 0;
+    iommu.reg_file.capabilities.Sv39x4 = 0;
+    iommu.reg_file.capabilities.Sv32x4 = 0;
     for ( i = 0; i < 4; i++ ) {
-        if ( i == 0 ) g_reg_file.capabilities.Sv32x4 = 1;
-        if ( i == 0 ) g_reg_file.fctl.gxl = 1;
+        if ( i == 0 ) iommu.reg_file.capabilities.Sv32x4 = 1;
+        if ( i == 0 ) iommu.reg_file.fctl.gxl = 1;
         if ( i == 0 ) DC.tc.SXL = 1;
-        if ( i == 1 ) g_reg_file.capabilities.Sv39x4 = 1;
-        if ( i == 2 ) g_reg_file.capabilities.Sv48x4 = 1;
-        if ( i == 3 ) g_reg_file.capabilities.Sv57x4 = 1;
+        if ( i == 1 ) iommu.reg_file.capabilities.Sv39x4 = 1;
+        if ( i == 2 ) iommu.reg_file.capabilities.Sv48x4 = 1;
+        if ( i == 3 ) iommu.reg_file.capabilities.Sv57x4 = 1;
         DC.iohgatp.MODE = IOHGATP_Bare;
         write_memory_test((char *)&DC, DC_addr, 64);
-        iodir(INVAL_DDT, 1, 0x012345, 0);
-        iotinval(VMA, 0, 0, 0, 0, 0, 0);
+        iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
+        iotinval(&iommu, VMA, 0, 0, 0, 0, 0, 0);
         gpa = 512UL * 512UL * PAGESIZE;
         req.tr.iova = gpa;
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         fail_if( ( rsp.trsp.U != 0 ) );
         fail_if( ( rsp.trsp.R != 1 ) );
@@ -1482,7 +1485,7 @@ main(void) {
         exp_trn_sz = i == 3 ? sv57_bare_sz : i == 2 ? sv48_bare_sz :
                      i == 1 ? sv39_bare_sz : sv32_bare_sz;
         fail_if( ((temp + 1) != exp_trn_sz) );
-        if ( i == 0 ) g_reg_file.fctl.gxl = 0;
+        if ( i == 0 ) iommu.reg_file.fctl.gxl = 0;
         if ( i == 0 ) DC.tc.SXL = 0;
     }
     END_TEST();
@@ -1509,43 +1512,43 @@ main(void) {
     gpa = 512UL * 512UL * 512UL * 512UL * PAGESIZE;
     gpa = gpa * 16;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012345, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
     gpa = gpa | ((1 << (i * 9)) * PAGESIZE) | 2048;
     req.tr.iova = gpa;
     gpte.PPN = 512UL * 512UL * 512UL * 512UL;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 4);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 4);
     read_memory_test(gpte_addr, 8, (char *)&gpte);
 
     gpte.U = 0;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
 
     gpte.U = 1;
     gpte.W = 1;
     gpte.R = 0;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
 
     gpte.X = 1;
     gpte.W = 0;
     gpte.R = 0;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
 
     gpte.PPN = 512UL * 512UL * 512UL ;
     gpte.X = 1;
@@ -1553,47 +1556,47 @@ main(void) {
     gpte.R = 1;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
     gpte.PPN = 512UL * 512UL * 512UL * 512UL;
     write_memory_test((char *)&gpte, gpte_addr, 8);
 
     gpte.reserved = 1;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
     gpte.reserved = 0;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
 
-    g_reg_file.capabilities.Svrsw60t59b = 1;
+    iommu.reg_file.capabilities.Svrsw60t59b = 1;
     gpte.rsw60t59b = 1;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    iotinval(GVMA, 0, 0, 0, 0, 0, 0);
-    g_reg_file.capabilities.Svrsw60t59b = 0;
+    iotinval(&iommu, GVMA, 0, 0, 0, 0, 0, 0);
+    iommu.reg_file.capabilities.Svrsw60t59b = 0;
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
     gpte.rsw60t59b = 0;
     write_memory_test((char *)&gpte, gpte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    iotinval(GVMA, 0, 0, 0, 0, 0, 0);
+    iotinval(&iommu, GVMA, 0, 0, 0, 0, 0, 0);
 
     access_viol_addr = gpte_addr;
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 7, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 7, 0) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
 
     tr_req_ctrl.DID = 0x012345;
     req.tr.iova &= ~0xFFF;
@@ -1602,32 +1605,32 @@ main(void) {
     tr_req_ctrl.go_busy = 1;
     tr_req_ctrl.Exe = 0;
     tr_req_iova.raw = req.tr.iova;
-    write_register(TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
-    write_register(TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
-    tr_response.raw = read_register(TR_RESPONSE_OFFSET, 8);
+    write_register(&iommu, TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
+    write_register(&iommu, TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
+    tr_response.raw = read_register(&iommu, TR_RESPONSE_OFFSET, 8);
     fail_if( ( tr_response.fault == 0 ) );
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
 
     access_viol_addr = -1;
 
     data_corruption_addr = gpte_addr;
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
 
     tr_req_ctrl.DID = 0x012345;
     tr_req_ctrl.PV = 0;
     tr_req_ctrl.NW = 1;
     tr_req_ctrl.go_busy = 1;
     tr_req_iova.raw = req.tr.iova;
-    write_register(TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
-    write_register(TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
-    tr_response.raw = read_register(TR_RESPONSE_OFFSET, 8);
+    write_register(&iommu, TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
+    write_register(&iommu, TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
+    tr_response.raw = read_register(&iommu, TR_RESPONSE_OFFSET, 8);
     fail_if( ( tr_response.fault == 0 ) );
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
 
     data_corruption_addr = -1;
     req.tr.iova = gpa;
@@ -1643,36 +1646,36 @@ main(void) {
     req.tr.at = ADDR_TYPE_UNTRANSLATED;
     req.tr.length = 64;
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
     gpte.PPN = 512UL * 512UL * 512UL ;
     write_memory_test((char *)&gpte, gpte_addr, 8);
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    iotinval(GVMA, 1, 0, 0, 1, 0, 0);
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
+    iotinval(&iommu, GVMA, 1, 0, 0, 1, 0, 0);
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 21, ((gpa >> 2) << 2)) < 0 ) );
     gpte.PPN = 512UL * 512UL * 512UL * 512UL;
     write_memory_test((char *)&gpte, gpte_addr, 8);
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    iotinval(GVMA, 1, 1, 0, 1, 0, req.tr.iova);
+    iotinval(&iommu, GVMA, 1, 1, 0, 1, 0, req.tr.iova);
     gpte.W = 0;
     write_memory_test((char *)&gpte, gpte_addr, 8);
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa >> 2) << 2)) < 0 ) );
     gpte.W = 1;
     write_memory_test((char *)&gpte, gpte_addr, 8);
-    iotinval(GVMA, 1, 1, 0, 1, 0, req.tr.iova);
-    iommu_translate_iova(&req, &rsp);
+    iotinval(&iommu, GVMA, 1, 1, 0, 1, 0, req.tr.iova);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
     END_TEST();
 
     START_TEST("S-stage translation sizes");
-    DC_addr = add_device(0x012349, 1, 1, 1, 0, 0, 1,
+    DC_addr = add_device(&iommu, 0x012349, 1, 1, 1, 0, 0, 1,
                          1, 1, 0, 0, 0,
                          IOHGATP_Bare, IOSATP_Sv57, PDTP_Bare,
                          MSIPTP_Off, 1, 0xF0F00FF0FF, 0x1903020124);
@@ -1709,7 +1712,7 @@ main(void) {
             gva = 512UL * 512UL * PAGESIZE;
         }
         write_memory_test((char *)&DC, DC_addr, 64);
-        iodir(INVAL_DDT, 1, 0x012349, 0);
+        iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
         for ( i = 0; i < 5; i++ ) {
             if ( (i == 4) && DC.fsc.iosatp.MODE != IOSATP_Sv57 ) continue;
             if ( (i == 3) && DC.fsc.iosatp.MODE != IOSATP_Sv48 &&
@@ -1719,7 +1722,7 @@ main(void) {
             pte.PPN = 512UL * 512UL * 512UL * 512UL;
             pte.PPN |= (1UL << (i * 9UL));
             pte_addr = add_s_stage_pte(DC.fsc.iosatp, gva, pte, i, DC.tc.SXL);
-            iommu_translate_iova(&req, &rsp);
+            iommu_translate_iova(&iommu, &req, &rsp);
             fail_if( ( rsp.status != SUCCESS ) );
             fail_if( ( rsp.trsp.S == 1 && i == 0 ) );
             fail_if( ( rsp.trsp.S == 0 && i != 0 ) );
@@ -1747,8 +1750,8 @@ main(void) {
                 pte.W = 0;
                 pte.R = 0;
                 write_memory_test((char *)&pte, pte_addr, 8);
-                iotinval(VMA, 0, 0, 0, 0, 0, 0);
-                iommu_translate_iova(&req, &rsp);
+                iotinval(&iommu, VMA, 0, 0, 0, 0, 0, 0);
+                iommu_translate_iova(&iommu, &req, &rsp);
                 fail_if( ( rsp.status != SUCCESS ) );
                 fail_if( ( rsp.trsp.R != 0 ) );
                 fail_if( ( rsp.trsp.W != 0 ) );
@@ -1756,28 +1759,28 @@ main(void) {
                 pte.W = 1;
                 pte.R = 1;
                 write_memory_test((char *)&pte, pte_addr, 8);
-                iotinval(VMA, 0, 0, 0, 0, 0, 0);
+                iotinval(&iommu, VMA, 0, 0, 0, 0, 0, 0);
             }
         }
     }
-    g_reg_file.capabilities.Sv57 = 0;
-    g_reg_file.capabilities.Sv48 = 0;
-    g_reg_file.capabilities.Sv39 = 0;
-    g_reg_file.capabilities.Sv32 = 0;
+    iommu.reg_file.capabilities.Sv57 = 0;
+    iommu.reg_file.capabilities.Sv48 = 0;
+    iommu.reg_file.capabilities.Sv39 = 0;
+    iommu.reg_file.capabilities.Sv32 = 0;
     for ( i = 0; i < 4; i++ ) {
-        if ( i == 0 ) g_reg_file.capabilities.Sv32 = 1;
-        if ( i == 0 ) g_reg_file.fctl.gxl = 1;
+        if ( i == 0 ) iommu.reg_file.capabilities.Sv32 = 1;
+        if ( i == 0 ) iommu.reg_file.fctl.gxl = 1;
         if ( i == 0 ) DC.tc.SXL = 1;
-        if ( i == 1 ) g_reg_file.capabilities.Sv39 = 1;
-        if ( i == 2 ) g_reg_file.capabilities.Sv48 = 1;
-        if ( i == 3 ) g_reg_file.capabilities.Sv57 = 1;
+        if ( i == 1 ) iommu.reg_file.capabilities.Sv39 = 1;
+        if ( i == 2 ) iommu.reg_file.capabilities.Sv48 = 1;
+        if ( i == 3 ) iommu.reg_file.capabilities.Sv57 = 1;
         DC.fsc.iosatp.MODE = IOSATP_Bare;
         write_memory_test((char *)&DC, DC_addr, 64);
-        iodir(INVAL_DDT, 1, 0x012349, 0);
-        iotinval(VMA, 0, 0, 0, 0, 0, 0);
+        iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
+        iotinval(&iommu, VMA, 0, 0, 0, 0, 0, 0);
         gva = 512UL * 512UL * PAGESIZE;
         req.tr.iova = gva;
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         fail_if( ( rsp.trsp.U != 0 ) );
         fail_if( ( rsp.trsp.R != 1 ) );
@@ -1791,19 +1794,19 @@ main(void) {
         exp_trn_sz = i == 3 ? sv57_bare_sz : i == 2 ? sv48_bare_sz :
                      i == 1 ? sv39_bare_sz : sv32_bare_sz;
         fail_if( ((temp + 1) != exp_trn_sz) );
-        if ( i == 0 ) g_reg_file.fctl.gxl = 0;
+        if ( i == 0 ) iommu.reg_file.fctl.gxl = 0;
         if ( i == 0 ) DC.tc.SXL = 0;
     }
 
     // IOTINVAL not allowed to set PSCV
-    iotinval(GVMA, 1, 1, 1, 1, 0, req.tr.iova);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iotinval(&iommu, GVMA, 1, 1, 1, 1, 0, req.tr.iova);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
 
     // Non-canonical addresses
     for ( j = 0; j < 3; j++ ) {
@@ -1823,11 +1826,11 @@ main(void) {
             i = 39;
         }
         write_memory_test((char *)&DC, DC_addr, 64);
-        iodir(INVAL_DDT, 1, 0x012349, 0);
+        iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
 
         while ( i < 64 ) {
             req.tr.iova = gva | 1ULL << i;
-            iommu_translate_iova(&req, &rsp);
+            iommu_translate_iova(&iommu, &req, &rsp);
             fail_if( ( rsp.status != SUCCESS ) );
             fail_if( ( rsp.trsp.R != 0 ) );
             fail_if( ( rsp.trsp.W != 0 ) );
@@ -1856,7 +1859,7 @@ main(void) {
     pte.PBMT = PMA;
     DC.fsc.iosatp.MODE = IOSATP_Sv57;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012349, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
     gva = 512UL * 512UL * 512UL * 512UL * PAGESIZE;
     gva = gva * 16;
     gva = gva | ((1 << (i * 9)) * PAGESIZE) | 2048;
@@ -1870,22 +1873,22 @@ main(void) {
     pte.R = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 15, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 15, 0) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
 
     pte.X = 1;
     pte.W = 0;
     pte.R = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 15, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 15, 0) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
 
     pte.PPN = 512UL * 512UL * 512UL ;
     pte.X = 1;
@@ -1893,71 +1896,71 @@ main(void) {
     pte.R = 1;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
     pte.PPN = 512UL * 512UL * 512UL * 512UL;
     write_memory_test((char *)&pte, pte_addr, 8);
 
     pte.PBMT = 3;
     write_memory_test((char *)&pte, pte_addr, 8);
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
     pte.PBMT = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
 
     pte.reserved = 1;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
     pte.reserved = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
 
-    g_reg_file.capabilities.Svrsw60t59b = 1;
+    iommu.reg_file.capabilities.Svrsw60t59b = 1;
     pte.rsw60t59b = 1;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    iotinval(VMA, 0, 0, 0, 0, 0, 0);
-    g_reg_file.capabilities.Svrsw60t59b = 0;
+    iotinval(&iommu, VMA, 0, 0, 0, 0, 0, 0);
+    iommu.reg_file.capabilities.Svrsw60t59b = 0;
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
     pte.rsw60t59b = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    iotinval(VMA, 0, 0, 0, 0, 0, 0);
+    iotinval(&iommu, VMA, 0, 0, 0, 0, 0, 0);
 
     access_viol_addr = pte_addr;
 
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 7, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 7, 0) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
 
     // Check DTF
-    temp = read_register(FQT_OFFSET, 4);
+    temp = read_register(&iommu, FQT_OFFSET, 4);
     DC.tc.DTF = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012349, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 0, 0) < 0 ) );
-    fail_if( ( temp != read_register(FQT_OFFSET, 4) ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 0, 0) < 0 ) );
+    fail_if( ( temp != read_register(&iommu, FQT_OFFSET, 4) ) );
     DC.tc.DTF = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012349, 0);
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
-    fail_if( ( temp == read_register(FQT_OFFSET, 4) ) );
+    iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
+    fail_if( ( temp == read_register(&iommu, FQT_OFFSET, 4) ) );
 
     req.tr.iova = req.tr.iova & ~0xFFF;
     tr_req_ctrl.DID = 0x012349;
@@ -1965,49 +1968,49 @@ main(void) {
     tr_req_ctrl.NW = 1;
     tr_req_ctrl.go_busy = 1;
     tr_req_iova.raw = req.tr.iova;
-    write_register(TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
-    write_register(TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
-    tr_response.raw = read_register(TR_RESPONSE_OFFSET, 8);
+    write_register(&iommu, TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
+    write_register(&iommu, TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
+    tr_response.raw = read_register(&iommu, TR_RESPONSE_OFFSET, 8);
     fail_if( ( tr_response.fault == 0 ) );
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 5, 0) < 0 ) );
 
     access_viol_addr = -1;
 
     data_corruption_addr = pte_addr;
 
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
 
     // Check DTF
-    temp = read_register(FQT_OFFSET, 4);
+    temp = read_register(&iommu, FQT_OFFSET, 4);
     DC.tc.DTF = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012349, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
     req.tr.read_writeAMO = READ;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 0, 0) < 0 ) );
-    fail_if( ( temp != read_register(FQT_OFFSET, 4) ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 0, 0) < 0 ) );
+    fail_if( ( temp != read_register(&iommu, FQT_OFFSET, 4) ) );
     DC.tc.DTF = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012349, 0);
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
-    fail_if( ( temp == read_register(FQT_OFFSET, 4) ) );
+    iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    fail_if( ( temp == read_register(&iommu, FQT_OFFSET, 4) ) );
 
     tr_req_ctrl.DID = 0x012349;
     tr_req_ctrl.PV = 0;
     tr_req_ctrl.NW = 1;
     tr_req_ctrl.go_busy = 1;
     tr_req_iova.raw = req.tr.iova;
-    write_register(TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
-    write_register(TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
-    tr_response.raw = read_register(TR_RESPONSE_OFFSET, 8);
+    write_register(&iommu, TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
+    write_register(&iommu, TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
+    tr_response.raw = read_register(&iommu, TR_RESPONSE_OFFSET, 8);
     fail_if( ( tr_response.fault == 0 ) );
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
 
     data_corruption_addr = -1;
     req.tr.iova = gva;
@@ -2027,45 +2030,45 @@ main(void) {
         pte.G = g;
         // AV=0, PSCV=0
         // Fill TLB
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         // Corrupt PTE
         pte.PPN = 512UL * 512UL * 512UL ;
         write_memory_test((char *)&pte, pte_addr, 8);
         // Hit in TLB
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         // Inv TLB
-        iotinval(VMA, 0, 0, 0, 1, 10, 0);
+        iotinval(&iommu, VMA, 0, 0, 0, 1, 10, 0);
         // Check fault observed - invalidate success
-        iommu_translate_iova(&req, &rsp);
-        fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+        iommu_translate_iova(&iommu, &req, &rsp);
+        fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
         // Correct fault
         pte.PPN = 512UL * 512UL * 512UL * 512UL;
         write_memory_test((char *)&pte, pte_addr, 8);
 
         // AV=0, PSCV=1
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         // Corrupt PTE
         pte.PPN = 512UL * 512UL * 512UL ;
         write_memory_test((char *)&pte, pte_addr, 8);
         // Hit in TLB
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         // Inv TLB - globals dont get flushed
-        iotinval(VMA, 0, 0, 1, 1, 10, 0);
+        iotinval(&iommu, VMA, 0, 0, 1, 1, 10, 0);
         // Check fault observed - invalidate success
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( g == 1 && rsp.status != SUCCESS ) );
-        fail_if( ( g == 0 && check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+        fail_if( ( g == 0 && check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
         if ( g == 1) {
             // Inv TLB - by address - flush globals
             // AV=1, PSCV=0
-            iotinval(VMA, 0, 1, 0, 1, 10, req.tr.iova);
+            iotinval(&iommu, VMA, 0, 1, 0, 1, 10, req.tr.iova);
             // Check fault observed - invalidate success
-            iommu_translate_iova(&req, &rsp);
-            fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+            iommu_translate_iova(&iommu, &req, &rsp);
+            fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
         }
         // Correct fault
         pte.PPN = 512UL * 512UL * 512UL * 512UL;
@@ -2073,19 +2076,19 @@ main(void) {
 
         // AV=1, PSCV=0
         // Fill TLB
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         // Corrupt PTE
         pte.PPN = 512UL * 512UL * 512UL ;
         write_memory_test((char *)&pte, pte_addr, 8);
         // Hit in TLB
-        iommu_translate_iova(&req, &rsp);
+        iommu_translate_iova(&iommu, &req, &rsp);
         fail_if( ( rsp.status != SUCCESS ) );
         // Inv TLB
-        iotinval(VMA, 0, 1, 0, 1, 10, req.tr.iova);
+        iotinval(&iommu, VMA, 0, 1, 0, 1, 10, req.tr.iova);
         // Check fault observed - invalidate success
-        iommu_translate_iova(&req, &rsp);
-        fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
+        iommu_translate_iova(&iommu, &req, &rsp);
+        fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 13, 0) < 0 ) );
         // Correct fault
         pte.PPN = 512UL * 512UL * 512UL * 512UL;
         write_memory_test((char *)&pte, pte_addr, 8);
@@ -2093,27 +2096,27 @@ main(void) {
     pte.W = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
     // Fill TLB
-    iommu_translate_iova(&req, &rsp);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
     // Fault from TLB
     pte.W = 1;
     write_memory_test((char *)&pte, pte_addr, 8);
     req.tr.read_writeAMO = WRITE;
-    iommu_translate_iova(&req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 15, 0) < 0 ) );
+    iommu_translate_iova(&iommu, &req, &rsp);
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 15, 0) < 0 ) );
     // Inv TLB
-    iotinval(VMA, 0, 0, 0, 1, 10, 0);
-    iommu_translate_iova(&req, &rsp);
+    iotinval(&iommu, VMA, 0, 0, 0, 1, 10, 0);
+    iommu_translate_iova(&iommu, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
     END_TEST();
 
     START_TEST("HPM filtering");
 
     for ( i = 0; i < 32; i++ ) {
-        write_register(IOHPMEVT1_OFFSET + (i * 8), 8, 0);
-        write_register(IOHPMCTR1_OFFSET + (i * 8), 8, 0);
+        write_register(&iommu, IOHPMEVT1_OFFSET + (i * 8), 8, 0);
+        write_register(&iommu, IOHPMCTR1_OFFSET + (i * 8), 8, 0);
     }
-    write_register(IOCNTINH_OFFSET, 4, 0);
+    write_register(&iommu, IOCNTINH_OFFSET, 4, 0);
 
     event.eventID = UNTRANSLATED_REQUEST;
     event.dmask = 0;
@@ -2123,22 +2126,22 @@ main(void) {
     event.dv_gscv = 1;
     event.idt = 0;
     event.of = 0;
-    write_register(IOHPMEVT1_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR1_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT1_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR1_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
 
     event.eventID = TRANSLATED_REQUEST;
     event.dmask = 1;
     event.did_gscid = 0x01237f;
-    write_register(IOHPMEVT2_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR2_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT2_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR2_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
 
     event.eventID = TRANSLATION_REQUEST;
     event.dmask = 1;
     event.did_gscid = 0x01237f;
     event.pv_pscv = 1;
     event.pid_pscid = 10;
-    write_register(IOHPMEVT3_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR3_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT3_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR3_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
 
 
     event.eventID = TRANSLATION_REQUEST;
@@ -2146,8 +2149,8 @@ main(void) {
     event.did_gscid = 0x01237f;
     event.dv_gscv = 0;
     event.pid_pscid = 10;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
 
     event.eventID = TRANSLATION_REQUEST;
     event.dmask = 1;
@@ -2155,77 +2158,77 @@ main(void) {
     event.dv_gscv = 0;
     event.pv_pscv = 0;
     event.pid_pscid = 10;
-    write_register(IOHPMEVT5_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR5_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT5_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR5_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
 
     for ( at = 0; at < 3; at++ ) {
-        send_translation_request(0x012349, 0, 10, 0,
+        send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, at, 0xdeadbeef, 1, READ, &req, &rsp);
-        send_translation_request(0x012349, 1, 10, 0,
+        send_translation_request(&iommu, 0x012349, 1, 10, 0,
              0, 0, 0, at, 0xdeadbeef, 1, READ, &req, &rsp);
-        send_translation_request(0x072349, 1, 10, 0,
+        send_translation_request(&iommu, 0x072349, 1, 10, 0,
              0, 0, 0, at, 0xdeadbeef, 1, READ, &req, &rsp);
     }
-    fail_if( ( read_register(IOHPMCTR1_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR2_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR3_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR5_OFFSET, 8) != 2 ) );
-    fail_if( ( (read_register(IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3E ) );
-    event.raw = read_register(IOHPMEVT1_OFFSET, 8);
+    fail_if( ( read_register(&iommu, IOHPMCTR1_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR2_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR3_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR5_OFFSET, 8) != 2 ) );
+    fail_if( ( (read_register(&iommu, IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3E ) );
+    event.raw = read_register(&iommu, IOHPMEVT1_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT1_OFFSET, 8, event.raw);
-    fail_if( ( (read_register(IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3C ) );
+    write_register(&iommu, IOHPMEVT1_OFFSET, 8, event.raw);
+    fail_if( ( (read_register(&iommu, IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3C ) );
 
     // Make counter 64 bit wide
-    g_hpmctr_bits = 64;
-    event.raw = read_register(IOHPMEVT1_OFFSET, 8);
+    iommu.hpmctr_bits = 64;
+    event.raw = read_register(&iommu, IOHPMEVT1_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT1_OFFSET, 8, event.raw);
-    event.raw = read_register(IOHPMEVT2_OFFSET, 8);
+    write_register(&iommu, IOHPMEVT1_OFFSET, 8, event.raw);
+    event.raw = read_register(&iommu, IOHPMEVT2_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT2_OFFSET, 8, event.raw);
-    event.raw = read_register(IOHPMEVT3_OFFSET, 8);
+    write_register(&iommu, IOHPMEVT2_OFFSET, 8, event.raw);
+    event.raw = read_register(&iommu, IOHPMEVT3_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT3_OFFSET, 8, event.raw);
-    event.raw = read_register(IOHPMEVT4_OFFSET, 8);
+    write_register(&iommu, IOHPMEVT3_OFFSET, 8, event.raw);
+    event.raw = read_register(&iommu, IOHPMEVT4_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    event.raw = read_register(IOHPMEVT5_OFFSET, 8);
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    event.raw = read_register(&iommu, IOHPMEVT5_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT5_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR1_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    write_register(IOHPMCTR2_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    write_register(IOHPMCTR3_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    write_register(IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    write_register(IOHPMCTR5_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT5_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR1_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMCTR2_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMCTR3_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMCTR5_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
 
     for ( at = 0; at < 3; at++ ) {
-        send_translation_request(0x012349, 0, 10, 0,
+        send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, at, 0xdeadbeef, 1, READ, &req, &rsp);
-        send_translation_request(0x012349, 1, 10, 0,
+        send_translation_request(&iommu, 0x012349, 1, 10, 0,
              0, 0, 0, at, 0xdeadbeef, 1, READ, &req, &rsp);
-        send_translation_request(0x072349, 1, 10, 0,
+        send_translation_request(&iommu, 0x072349, 1, 10, 0,
              0, 0, 0, at, 0xdeadbeef, 1, READ, &req, &rsp);
     }
-    fail_if( ( read_register(IOHPMCTR1_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR2_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR3_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR5_OFFSET, 8) != 2 ) );
-    fail_if( ( (read_register(IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3E ) );
-    event.raw = read_register(IOHPMEVT1_OFFSET, 8);
+    fail_if( ( read_register(&iommu, IOHPMCTR1_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR2_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR3_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR5_OFFSET, 8) != 2 ) );
+    fail_if( ( (read_register(&iommu, IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3E ) );
+    event.raw = read_register(&iommu, IOHPMEVT1_OFFSET, 8);
     event.of = 0;
-    write_register(IOHPMEVT1_OFFSET, 8, event.raw);
-    fail_if( ( (read_register(IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3C ) );
+    write_register(&iommu, IOHPMEVT1_OFFSET, 8, event.raw);
+    fail_if( ( (read_register(&iommu, IOCNTOVF_OFFSET, 4) & 0xFFFFFFFF) != 0x3C ) );
 
     // Put the counter width back to 40
-    write_register(IOHPMCTR1_OFFSET, 8, 0x0);
-    write_register(IOHPMCTR2_OFFSET, 8, 0x0);
-    write_register(IOHPMCTR3_OFFSET, 8, 0x0);
-    write_register(IOHPMCTR4_OFFSET, 8, 0x0);
-    write_register(IOHPMCTR5_OFFSET, 8, 0x0);
-    g_hpmctr_bits = 40;
+    write_register(&iommu, IOHPMCTR1_OFFSET, 8, 0x0);
+    write_register(&iommu, IOHPMCTR2_OFFSET, 8, 0x0);
+    write_register(&iommu, IOHPMCTR3_OFFSET, 8, 0x0);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0x0);
+    write_register(&iommu, IOHPMCTR5_OFFSET, 8, 0x0);
+    iommu.hpmctr_bits = 40;
 
     pte.raw = 0;
     pte.V = 1;
@@ -2240,7 +2243,7 @@ main(void) {
     DC.fsc.iosatp.MODE = IOSATP_Sv57;
     DC.ta.PSCID = 10;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x012349, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x012349, 0);
     gva = 512UL * 512UL * 512UL * 512UL * PAGESIZE;
     gva = gva * 24;
     gva = gva | ((1 << (i * 9)) * PAGESIZE) | 2048;
@@ -2256,74 +2259,74 @@ main(void) {
     event.dv_gscv = 0;
     event.idt = 1;
     event.of = 0;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    send_translation_request(0x012349, 0, 10, 0,
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 0 ) );
-    send_translation_request(0x012349, 0, 10, 0,
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 0 ) );
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 0 ) );
 
     // Inv TLB
-    iotinval(VMA, 0, 0, 0, 1, 10, 0);
-    send_translation_request(0x012349, 0, 10, 0,
+    iotinval(&iommu, VMA, 0, 0, 0, 1, 10, 0);
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 1 ) );
 
     // Inv TLB
-    iotinval(VMA, 0, 0, 0, 1, 10, 0);
+    iotinval(&iommu, VMA, 0, 0, 0, 1, 10, 0);
     event.pv_pscv = 0;
     event.dv_gscv = 0;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    send_translation_request(0x012349, 0, 10, 0,
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 0 ) );
-    send_translation_request(0x012349, 0, 10, 0,
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 0 ) );
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
 
     // Inv TLB
-    iotinval(VMA, 0, 0, 0, 1, 10, 0);
+    iotinval(&iommu, VMA, 0, 0, 0, 1, 10, 0);
     event.pv_pscv = 0;
     event.dv_gscv = 1;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
-    send_translation_request(0x012349, 0, 10, 0,
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 0xffffffffff ));
-    send_translation_request(0x012349, 0, 10, 0,
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 0xffffffffff ));
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 0xffffffffff ));
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 0xffffffffff ));
 
 
     event.pv_pscv = 1;
     event.dv_gscv = 1;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    iotinval(VMA, 0, 0, 0, 1, 10, 0);
-    send_translation_request(0x012349, 0, 10, 0,
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    iotinval(&iommu, VMA, 0, 0, 0, 1, 10, 0);
+    send_translation_request(&iommu, 0x012349, 0, 10, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva, 1, READ, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8)  != 0xffffffffff ));
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8)  != 0xffffffffff ));
 
     for ( i = 0; i < 32; i++ ) {
-        write_register(IOHPMEVT1_OFFSET + (i * 8), 8, 0);
-        write_register(IOHPMCTR1_OFFSET + (i * 8), 8, 0);
+        write_register(&iommu, IOHPMEVT1_OFFSET + (i * 8), 8, 0);
+        write_register(&iommu, IOHPMCTR1_OFFSET + (i * 8), 8, 0);
     }
 
     END_TEST();
 
     START_TEST("Process Directory Table walk");
     // collapse fault queue
-    write_register(FQH_OFFSET, 4, read_register(FQT_OFFSET, 4));
-    DC_addr = add_device(0x112233, 0x1234, 0, 0, 0, 0, 0,
+    write_register(&iommu, FQH_OFFSET, 4, read_register(&iommu, FQT_OFFSET, 4));
+    DC_addr = add_device(&iommu, 0x112233, 0x1234, 0, 0, 0, 0, 0,
                          1, 1, 0, 0, 0,
                          IOHGATP_Sv48x4, IOSATP_Bare, PD20,
                          MSIPTP_Flat, 1, 0xFFFFFFFFFF, 0x1000000000);
@@ -2332,26 +2335,26 @@ main(void) {
     write_memory_test((char *)&DC, DC_addr, 64);
 
     // Invalid non-leaf PDTE
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 266, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 266, 0) < 0 ) );
 
     // Access viol on non-leaf PDTE
     fail_if( (translate_gpa(DC.iohgatp, DC.fsc.pdtp.PPN * PAGESIZE, &temp) == -1) );
     access_viol_addr = (temp) | (get_bits(19, 17, 0xBABEC) * 8);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 265, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 265, 0) < 0 ) );
 
     // Data corruption on non-leaf PDTE
     data_corruption_addr = access_viol_addr;
     access_viol_addr = -1;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 269, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 269, 0) < 0 ) );
     data_corruption_addr = -1;
 
 
@@ -2370,12 +2373,12 @@ main(void) {
     gpte.D = 0;
     gpte.PBMT = PMA;
     gpte.PPN = get_free_ppn(1);
-    add_g_stage_pte(DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
+    add_g_stage_pte(&iommu, DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
     PC.ta.V = 1;
     PC.ta.PSCID = 10;
     PC.ta.ENS = 1;
     PC.ta.SUM = 1;
-    PC_addr = add_process_context(&DC, &PC, 0xBABEC);
+    PC_addr = add_process_context(&iommu, &DC, &PC, 0xBABEC);
     fail_if( (read_memory_test(PC_addr, 16, (char *)&PC) != 0) );
 
     // misconfigured NL PTE
@@ -2384,37 +2387,37 @@ main(void) {
     read_memory_test(temp, 8, (char *)&pdte);
     pdte.reserved0 = 1;
     write_memory_test((char *)&pdte, temp, 8);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
     pdte.reserved0 = 0;
     write_memory_test((char *)&pdte, temp, 8);
 
     // Misconfigured PC
     PC.ta.reserved0 = 1;
     write_memory_test((char *)&PC, PC_addr, 16);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
     PC.ta.reserved0 = 0;
     write_memory_test((char *)&PC, PC_addr, 16);
     PC.ta.reserved1 = 1;
     write_memory_test((char *)&PC, PC_addr, 16);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
     PC.ta.reserved1 = 0;
     write_memory_test((char *)&PC, PC_addr, 16);
     PC.ta.reserved0 = 1;
     PC.ta.reserved1 = 1;
     write_memory_test((char *)&PC, PC_addr, 16);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
     PC.ta.reserved0 = 0;
     PC.ta.reserved1 = 0;
     write_memory_test((char *)&PC, PC_addr, 16);
@@ -2422,48 +2425,48 @@ main(void) {
     // Invalid PC
     PC.ta.V = 0;
     write_memory_test((char *)&PC, PC_addr, 16);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 266, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 266, 0) < 0 ) );
     PC.ta.V = 1;
     write_memory_test((char *)&PC, PC_addr, 16);
 
     // PC access violation
     access_viol_addr = PC_addr;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 265, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 265, 0) < 0 ) );
     access_viol_addr = -1;
     // PC data corruption violation
     data_corruption_addr = PC_addr;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 269, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 269, 0) < 0 ) );
     data_corruption_addr = -1;
 
-    g_reg_file.fctl.gxl = 0;
+    iommu.reg_file.fctl.gxl = 0;
     DC.tc.SXL = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    g_reg_file.capabilities.Sv57 = 0;
-    g_reg_file.capabilities.Sv48 = 0;
-    g_reg_file.capabilities.Sv39 = 0;
-    g_reg_file.capabilities.Sv32 = 0;
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    iommu.reg_file.capabilities.Sv57 = 0;
+    iommu.reg_file.capabilities.Sv48 = 0;
+    iommu.reg_file.capabilities.Sv39 = 0;
+    iommu.reg_file.capabilities.Sv32 = 0;
     for ( j = 1; j < 16; j++ ) {
         PC.fsc.iosatp.MODE = j;
         write_memory_test((char *)&PC, PC_addr, 16);
-        send_translation_request(0x112233, 1, 0xBABEC, 0,
+        send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-        fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+        fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
     }
-    g_reg_file.capabilities.Sv57 = 1;
-    g_reg_file.capabilities.Sv48 = 1;
-    g_reg_file.capabilities.Sv39 = 1;
-    g_reg_file.capabilities.Sv32 = 1;
+    iommu.reg_file.capabilities.Sv57 = 1;
+    iommu.reg_file.capabilities.Sv48 = 1;
+    iommu.reg_file.capabilities.Sv39 = 1;
+    iommu.reg_file.capabilities.Sv32 = 1;
     PC.fsc.iosatp.MODE = IOSATP_Sv48;
     write_memory_test((char *)&PC, PC_addr, 16);
 
@@ -2474,31 +2477,31 @@ main(void) {
     read_memory_test(temp, 8, (char *)&gpte);
     gpte.V = 0;
     write_memory_test((char *)&gpte, temp, 8);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa & ~0x3UL) | 1)) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, ((gpa & ~0x3UL) | 1)) < 0 ) );
     gpte.V = 1;
     write_memory_test((char *)&gpte, temp, 8);
 
     // GPTE access fault
     access_viol_addr = temp;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 265, 0 ) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 265, 0 ) < 0 ) );
     access_viol_addr = -1;
 
     // GPTE data corruption
     data_corruption_addr = temp;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
     data_corruption_addr = -1;
 
     // Two stage translation
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     pte.raw = 0;
     pte.V = 1;
     pte.R = 1;
@@ -2524,177 +2527,177 @@ main(void) {
     gpte.PPN = get_free_ppn(1);
     gpa = pte.PPN * PAGESIZE;
     spa = gpte.PPN * PAGESIZE;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 0);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 0);
     gva = 0x100000;
-    pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
 
     // fail_if if PC was cached
     PC.fsc.iosatp.reserved = 1;
     write_memory_test((char *)&PC, PC_addr, 16);
-    iotinval(VMA, 1, 1, 1, 0x1234, 10, gva);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iotinval(&iommu, VMA, 1, 1, 1, 0x1234, 10, gva);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
 
     // Invalidate PC - DV must be 1
-    iodir(INVAL_PDT, 0, 0x112233, 0xBABEC);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iodir(&iommu, INVAL_PDT, 0, 0x112233, 0xBABEC);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
 
     // fix the illegal commend
-    cqb.raw = read_register(CQB_OFFSET, 8);
-    cqh.raw = read_register(CQH_OFFSET, 4);
+    cqb.raw = read_register(&iommu, CQB_OFFSET, 8);
+    cqh.raw = read_register(&iommu, CQH_OFFSET, 4);
     read_memory_test(((cqb.ppn * PAGESIZE) | (cqh.index * 16)), 16, (char *)&cmd);
     cmd.iodir.dv = 1;
     write_memory_test((char *)&cmd, ((cqb.ppn * PAGESIZE) | (cqh.index * 16)), 16);
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
 
     // Invalidate PC - DID must not be too wide
-    g_max_devid_mask = 0x3F;
-    process_commands();
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iommu.max_devid_mask = 0x3F;
+    process_commands(&iommu);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
-    g_max_devid_mask = 0xFFFFFF;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    iommu.max_devid_mask = 0xFFFFFF;
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
 
     // Process the fixed up command
-    process_commands();
+    process_commands(&iommu);
 
     // should observe misconiguration
-    iotinval(VMA, 1, 1, 1, 0x1234, 10, gva);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iotinval(&iommu, VMA, 1, 1, 1, 0x1234, 10, gva);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
 
     // Fix PC Translation should succeed
     PC.fsc.iosatp.reserved = 0;
     write_memory_test((char *)&PC, PC_addr, 16);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
 
     // Check A/D update from TLB
     read_memory_test(pte_addr, 8, (char *)&pte);
     pte.A = pte.D = 0;
     write_memory_test((char *)&pte, pte_addr, 8);
-    iotinval(VMA, 1, 1, 1, 0x1234, 10, gva);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iotinval(&iommu, VMA, 1, 1, 1, 0x1234, 10, gva);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     read_memory_test(pte_addr, 8, (char *)&pte);
     fail_if( ( pte.A == 0 ) );
     fail_if( ( pte.D == 1 ) );
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     read_memory_test(pte_addr, 8, (char *)&pte);
     fail_if( ( pte.A == 0 ) );
     fail_if( ( pte.D == 0 ) );
 
     // transaction with no PASID
-    send_translation_request(0x112233, 0, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 0, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gpa,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != (spa / PAGESIZE) ) );
 
     // Test T2GPA
     DC.tc.T2GPA = 1;
     DC.tc.EN_ATS = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != (gpa / PAGESIZE) ) );
-    send_translation_request(0x112233, 0, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 0, 0xBABEC, 0,
              0, 1, 0, TRANSLATED_REQUEST, gpa,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != (spa / PAGESIZE) ) );
 
     // Disable T2GPA and test 2 stage translation
     DC.tc.T2GPA = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != (spa / PAGESIZE) ) );
-    send_translation_request(0x112233, 0, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 0, 0xBABEC, 0,
              0, 1, 0, TRANSLATED_REQUEST, spa,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != (spa / PAGESIZE) ) );
 
     // Disable supervisory requests
     PC.ta.ENS = 0;
     write_memory_test((char *)&PC, PC_addr, 64);
-    iodir(INVAL_PDT, 1, 0x112233, 0xBABEC);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBABEC);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
 
     // Disable supv to user access
     PC.ta.ENS = 1;
     PC.ta.SUM = 0;
     write_memory_test((char *)&PC, PC_addr, 64);
-    iodir(INVAL_PDT, 1, 0x112233, 0xBABEC);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBABEC);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.R != 0 ) );
     fail_if( ( rsp.trsp.W != 0 ) );
     fail_if( ( rsp.trsp.Exe != 0 ) );
 
     // Cause a PDT access fault
     access_viol_addr = PC_addr;
-    iodir(INVAL_PDT, 1, 0x112233, 0xBABEC);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBABEC);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, COMPLETER_ABORT, 265, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, COMPLETER_ABORT, 265, 0) < 0 ) );
     access_viol_addr = -1;
-    iodir(INVAL_PDT, 1, 0x112233, 0xBABEC);
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBABEC);
 
     // Too wide PID and invalid PDTP mode
     DC.fsc.pdtp.MODE = PD8;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
     DC.fsc.pdtp.MODE = PD17;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 260, 0) < 0 ) );
     DC.fsc.pdtp.MODE = 9;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 259, 0) < 0 ) );
     DC.fsc.pdtp.MODE = PD20;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
 
     // Do a napot PTE
     pte.raw = 0;
@@ -2727,22 +2730,22 @@ main(void) {
     gpte.PPN = get_free_ppn(16);
     spa = gpte.PPN * PAGESIZE;
     gpte.PPN |= 0x4;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 0);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 0);
     gva = 0x900000;
-    pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23, gpa) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23, gpa) < 0 ) );
     read_memory_test(gpte_addr, 8, (char *)&gpte);
     gpte.PPN &= ~0x4;
     gpte.PPN |= 0x8;
     write_memory_test((char *)&gpte.raw, gpte_addr, 8);
 
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.S != 0 ) );
     fail_if( ( rsp.trsp.PPN != (gpte.PPN & ~0x8)) );
 
@@ -2752,27 +2755,27 @@ main(void) {
     read_memory_test(gpte_addr, 8, (char *)&gpte);
     gpte.V = 0;
     write_memory_test((char *)&gpte.raw, gpte_addr, 8);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23,
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23,
                ((PC.fsc.iosatp.PPN * PAGESIZE) | 3)) < 0 ) );
 
     gpte.V = 1;
     gpte.N = 1;
     write_memory_test((char *)&gpte.raw, gpte_addr, 8);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23,
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23,
                ((PC.fsc.iosatp.PPN * PAGESIZE) | 3)) < 0 ) );
     gpte.N = 0;
     gpte.PBMT = 1;
     write_memory_test((char *)&gpte.raw, gpte_addr, 8);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 23,
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 23,
                ((PC.fsc.iosatp.PPN * PAGESIZE) | 3)) < 0 ) );
     gpte.N = 0;
     gpte.PBMT = 0;
@@ -2780,26 +2783,26 @@ main(void) {
 
     // Access violation on NL S-stage PTE
     access_viol_addr = gpte_addr;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 7, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 7, 0) < 0 ) );
     access_viol_addr = -1;
 
     // Data corruption on NL S-stage PTE
     data_corruption_addr = gpte_addr;
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 274, 0) < 0 ) );
     data_corruption_addr = -1;
 
 
 
 
 
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    iotinval(GVMA, 1, 0, 0, 0x1234, 0, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    iotinval(&iommu, GVMA, 1, 0, 0, 0x1234, 0, 0);
     for ( i = 0; i < 10; i++ ) {
         // Add process context
         memset(&PC, 0, 16);
@@ -2816,12 +2819,12 @@ main(void) {
         gpte.D = 0;
         gpte.PBMT = PMA;
         gpte.PPN = get_free_ppn(1);
-        add_g_stage_pte(DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
+        add_g_stage_pte(&iommu, DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
         PC.ta.V = 1;
         PC.ta.PSCID = 100+i;
         PC.ta.ENS = 1;
         PC.ta.SUM = 1;
-        PC_addr = add_process_context(&DC, &PC, 0x1000+i);
+        PC_addr = add_process_context(&iommu, &DC, &PC, 0x1000+i);
         read_memory_test(PC_addr, 16, (char *)&PC);
         pte.raw = 0;
         pte.V = 1;
@@ -2848,22 +2851,22 @@ main(void) {
         gpte.PPN = get_free_ppn(1);
         gpa = pte.PPN * PAGESIZE;
         spa = gpte.PPN * PAGESIZE;
-        gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 0);
+        gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 0);
         gva = 0x100000;
-        pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
+        pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
     }
     for ( i = 0; i < 10; i++ ) {
-        send_translation_request(0x112233, 1, 0x1000+i, 0,
+        send_translation_request(&iommu, 0x112233, 1, 0x1000+i, 0,
                  0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
                  1, WRITE, &req, &rsp);
-        fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+        fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     }
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    iotinval(GVMA, 1, 0, 0, 0x1234, 0, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    iotinval(&iommu, GVMA, 1, 0, 0, 0x1234, 0, 0);
 
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
-    write_register(IPSR_OFFSET,4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET,4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.pmip == 1 ) );
 
     gva = 0x100000;
@@ -2876,64 +2879,64 @@ main(void) {
 
     event.pv_pscv = 0;
     event.dv_gscv = 0;
-    write_register(IOHPMEVT1_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR1_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT1_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR1_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
     event.pv_pscv = 1;
     event.dv_gscv = 0;
-    write_register(IOHPMEVT2_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR2_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT2_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR2_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
     event.pv_pscv = 0;
     event.dv_gscv = 1;
-    write_register(IOHPMEVT3_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR3_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
+    write_register(&iommu, IOHPMEVT3_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR3_OFFSET, 8, 0xFFFFFFFFFFFFFFFF);
     event.pv_pscv = 1;
     event.dv_gscv = 1;
-    write_register(IOHPMEVT4_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR4_OFFSET, 8, 0x0);
+    write_register(&iommu, IOHPMEVT4_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR4_OFFSET, 8, 0x0);
     event.dmask = 1;
     event.did_gscid = 0x127f;
-    write_register(IOHPMEVT5_OFFSET, 8, event.raw);
-    write_register(IOHPMCTR5_OFFSET, 8, 0x9);
+    write_register(&iommu, IOHPMEVT5_OFFSET, 8, event.raw);
+    write_register(&iommu, IOHPMCTR5_OFFSET, 8, 0x9);
 
-    send_translation_request(0x112233, 1, 0x1000, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0x1000, 0,
                  0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
                  1, WRITE, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR1_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR2_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR3_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 1 ) );
-    fail_if( ( read_register(IOHPMCTR5_OFFSET, 8) != 0xa ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR1_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR2_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR3_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR5_OFFSET, 8) != 0xa ) );
 
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.pmip == 1 ) );
-    g_reg_file.capabilities.hpm = 0;
+    iommu.reg_file.capabilities.hpm = 0;
 
-    send_translation_request(0x112233, 1, 0x1000, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0x1000, 0,
                  0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
                  1, WRITE, &req, &rsp);
     fail_if( ( rsp.status != SUCCESS ) );
-    fail_if( ( read_register(IOHPMCTR1_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR2_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR3_OFFSET, 8) != 0 ) );
-    fail_if( ( read_register(IOHPMCTR4_OFFSET, 8) != 1 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR1_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR2_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR3_OFFSET, 8) != 0 ) );
+    fail_if( ( read_register(&iommu, IOHPMCTR4_OFFSET, 8) != 1 ) );
 
     for ( i = 0; i < 32; i++ ) {
-        write_register(IOHPMEVT1_OFFSET + (i * 8), 8, 0);
-        write_register(IOHPMCTR1_OFFSET + (i * 8), 8, 0);
+        write_register(&iommu, IOHPMEVT1_OFFSET + (i * 8), 8, 0);
+        write_register(&iommu, IOHPMCTR1_OFFSET + (i * 8), 8, 0);
     }
 //HERE
     // Two stage translation with default process ID
     // Enable default process
     DC.tc.DPE = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
 
     // transaction with no PASID - should fail as no default process context
-    send_translation_request(0x112233, 0, 0, 0,
+    send_translation_request(&iommu, 0x112233, 0, 0, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0x10000,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 266, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 266, 0) < 0 ) );
     DC.tc.DPE = 0;
 
 #if 0
@@ -2953,12 +2956,12 @@ main(void) {
     gpte.D = 0;
     gpte.PBMT = PMA;
     gpte.PPN = get_free_ppn(1);
-    add_g_stage_pte(DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
+    add_g_stage_pte(&iommu, DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
     PC.ta.V = 1;
     PC.ta.PSCID = 10;
     PC.ta.ENS = 1;
     PC.ta.SUM = 1;
-    PC_addr = add_process_context(&DC, &PC, 0xBABEC);
+    PC_addr = add_process_context(&iommu, &DC, &PC, 0xBABEC);
     read_memory_test(PC_addr, 16, (char *)&PC);
 
     pte.raw = 0;
@@ -2986,18 +2989,18 @@ main(void) {
     gpte.PPN = get_free_ppn(1);
     gpa = pte.PPN * PAGESIZE;
     spa = gpte.PPN * PAGESIZE;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 0);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 0);
     gva = 0x100000;
-    pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 0, DC.iohgatp);
-    send_translation_request(0x112233, 1, 0xBABEC, 0,
+    pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 0, DC.iohgatp);
+    send_translation_request(&iommu, 0x112233, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
 #endif
 
     DC.tc.PDTV = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
 
     // Add process context
     memset(&PC, 0, 16);
@@ -3014,12 +3017,12 @@ main(void) {
     gpte.D = 0;
     gpte.PBMT = PMA;
     gpte.PPN = get_free_ppn(1);
-    add_g_stage_pte(DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
+    add_g_stage_pte(&iommu, DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
     PC.ta.V = 1;
     PC.ta.PSCID = 7000;
     PC.ta.ENS = 1;
     PC.ta.SUM = 1;
-    PC_addr = add_process_context(&DC, &PC, 0x7000);
+    PC_addr = add_process_context(&iommu, &DC, &PC, 0x7000);
     read_memory_test(PC_addr, 16, (char *)&PC);
     pte.raw = 0;
     pte.V = 1;
@@ -3046,14 +3049,14 @@ main(void) {
     gpte.PPN = get_free_ppn(1);
     gpa = pte.PPN * PAGESIZE;
     spa = gpte.PPN * PAGESIZE;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 0);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 0);
     gva = 0x900000;
-    pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
+    pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
 
-    send_translation_request(0x112233, 1, 0x7000, 1, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0x7000, 1, 0,
                              0, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, 0x900000,
                              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.status != SUCCESS ) );
     fail_if( ( rsp.trsp.U != 0 ) );
     fail_if( ( rsp.trsp.R != 1 ) );
@@ -3063,10 +3066,10 @@ main(void) {
     fail_if( ( rsp.trsp.is_msi != 0 ) );
     fail_if( ( rsp.trsp.S != 0 ) );
 
-    send_translation_request(0x112233, 1, 0x7000, 0, 0,
+    send_translation_request(&iommu, 0x112233, 1, 0x7000, 0, 0,
                              0, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, 0x900000,
                              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.status != SUCCESS ) );
     fail_if( ( rsp.trsp.U != 0 ) );
     fail_if( ( rsp.trsp.R != 1 ) );
@@ -3091,10 +3094,10 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = 0xdeadbeeffeedbeef;
-    ats_command(PRGR, 1, 1, 0xbabec, 0x43, 0x1234, 0xdeadbeeffeedbeef);
+    ats_command(&iommu, PRGR, 1, 1, 0xbabec, 0x43, 0x1234, 0xdeadbeeffeedbeef);
     fail_if( ( exp_msg_received == 0 ) );
     exp_msg.PV = 0;
-    ats_command(PRGR, 1, 0, 0xbabec, 0x43, 0x1234, 0xdeadbeeffeedbeef);
+    ats_command(&iommu, PRGR, 1, 0, 0xbabec, 0x43, 0x1234, 0xdeadbeeffeedbeef);
     fail_if( ( exp_msg_received == 0 ) );
     END_TEST();
 
@@ -3120,9 +3123,9 @@ main(void) {
     exp_msg.DSV = 1;
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = (0x1234UL << 48UL) | (PRGR_RESPONSE_FAILURE << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(258, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 258, pr.PV, pr.PID, pr.PRIV, 0x431234, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
 
     // ATS disabled
     pr.RID = 0x2233;
@@ -3130,15 +3133,15 @@ main(void) {
     DC.tc.EN_ATS = 0;
     DC.tc.EN_PRI = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     exp_msg.RID = 0x2233;
     exp_msg.DSEG = 0x11;
     exp_msg.PV = 0;
     exp_msg.PID = 0;
     exp_msg.PAYLOAD = (0x2233UL << 48UL) | (PRGR_INVALID_REQUEST << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(260, pr.PV, pr.PID, pr.PRIV, 0x112233, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 260, pr.PV, pr.PID, pr.PRIV, 0x112233, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
 
     // ATS enabled PRI disabled
     pr.RID = 0x2233;
@@ -3146,42 +3149,42 @@ main(void) {
     DC.tc.EN_ATS = 1;
     DC.tc.EN_PRI = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     exp_msg.RID = 0x2233;
     exp_msg.DSEG = 0x11;
     exp_msg.PV = 0;
     exp_msg.PID = 0;
     exp_msg.PAYLOAD = (0x2233UL << 48UL) | (PRGR_INVALID_REQUEST << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( check_faults(260, pr.PV, pr.PID, pr.PRIV, 0x112233, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 260, pr.PV, pr.PID, pr.PRIV, 0x112233, PAGE_REQ_MSG_CODE, PCIE_MESSAGE_REQUEST, 0) < 0 ) );
 
 
     // ATS, PRI enabled - Page request queue disabled
-    fail_if( ( enable_disable_pq(4, 0) < 0 ) );
+    fail_if( ( enable_disable_pq(&iommu, 4, 0) < 0 ) );
     DC.tc.EN_ATS = 1;
     DC.tc.EN_PRI = 1;
     DC.tc.PRPR = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     exp_msg.RID = 0x2233;
     exp_msg.DSEG = 0x11;
     exp_msg.PV = 1;
     exp_msg.PID = 0xBABEC;
     exp_msg.PAYLOAD = (0x2233UL << 48UL) | (PRGR_RESPONSE_FAILURE << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( exp_msg_received == 0 ) );
-    fail_if( ( ((read_register(PQH_OFFSET, 4)) != read_register(PQT_OFFSET, 4)) ) );
-    fail_if( ( enable_disable_pq(4, 1) < 0 ) );
+    fail_if( ( ((read_register(&iommu, PQH_OFFSET, 4)) != read_register(&iommu, PQT_OFFSET, 4)) ) );
+    fail_if( ( enable_disable_pq(&iommu, 4, 1) < 0 ) );
 
     // Test that write to pqen when register is busy is discarded
-    g_reg_file.pqcsr.busy = 1;
+    iommu.reg_file.pqcsr.busy = 1;
     pqcsr.pqen = 0;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    pqcsr.raw = read_register(PQCSR_OFFSET, 4);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    pqcsr.raw = read_register(&iommu, PQCSR_OFFSET, 4);
     fail_if( ( pqcsr.pqen == 0 ) );
     fail_if( ( pqcsr.pqon == 0 ) );
-    g_reg_file.pqcsr.busy = 0;
+    iommu.reg_file.pqcsr.busy = 0;
 
     // PRI enabled - should queue in PQ
     pr.RID = 0x2233;
@@ -3189,15 +3192,15 @@ main(void) {
     DC.tc.EN_ATS = 1;
     DC.tc.EN_PRI = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     message_received = 0;
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 1 ) );
 
     // Create a overflow case
-    pqb.raw = read_register(PQB_OFFSET, 8);
-    write_register(PQH_OFFSET, 4,
-        (read_register(PQT_OFFSET, 4) + 1) & ((1UL << (pqb.log2szm1 + 1)) - 1));
+    pqb.raw = read_register(&iommu, PQB_OFFSET, 8);
+    write_register(&iommu, PQH_OFFSET, 4,
+        (read_register(&iommu, PQT_OFFSET, 4) + 1) & ((1UL << (pqb.log2szm1 + 1)) - 1));
 
     pr.RID = 0x2233;
     pr.DSEG = 0x11;
@@ -3205,78 +3208,78 @@ main(void) {
     DC.tc.EN_PRI = 1;
     DC.tc.PRPR = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     message_received = 0;
     exp_msg.RID = 0x2233;
     exp_msg.DSEG = 0x11;
     exp_msg.PV = 0;
     exp_msg.PID = 0;
     exp_msg.PAYLOAD = (0x2233UL << 48UL) | (PRGR_SUCCESS << 44UL);
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
     // Set PRPR
     DC.tc.PRPR = 1;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x112233, 0);
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
     exp_msg.PV = 1;
     exp_msg.PID = 0xBABEC;
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
     // PR without LPIG
     pr.PAYLOAD = 0xdeadbeef00000003; // Set last = 0, PRG index = 0
     message_received = 0;
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 1 ) );
 
     // Clear overflow - and observe logging
-    write_register(PQH_OFFSET, 4, read_register(PQT_OFFSET, 4));
-    write_register(PQCSR_OFFSET, 4, read_register(PQCSR_OFFSET, 4));
+    write_register(&iommu, PQH_OFFSET, 4, read_register(&iommu, PQT_OFFSET, 4));
+    write_register(&iommu, PQCSR_OFFSET, 4, read_register(&iommu, PQCSR_OFFSET, 4));
     message_received = 0;
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 1 ) );
-    fail_if( ( read_register(PQH_OFFSET, 4) == read_register(PQT_OFFSET, 4) ) );
-    fail_if( ( check_exp_pq_rec(0x112233, 0xBABEC, 1, 1, 0, 0, 0, pr.PAYLOAD) < 0 ) );
+    fail_if( ( read_register(&iommu, PQH_OFFSET, 4) == read_register(&iommu, PQT_OFFSET, 4) ) );
+    fail_if( ( check_exp_pq_rec(&iommu, 0x112233, 0xBABEC, 1, 1, 0, 0, 0, pr.PAYLOAD) < 0 ) );
 
     // cause memory fault
-    pqb.raw = read_register(PQB_OFFSET, 8);
+    pqb.raw = read_register(&iommu, PQB_OFFSET, 8);
     access_viol_addr = (pqb.ppn * PAGESIZE);
-    access_viol_addr += (read_register(PQT_OFFSET, 4) * 16);
+    access_viol_addr += (read_register(&iommu, PQT_OFFSET, 4) * 16);
     pr.PAYLOAD = 0xdeadbeef00000007; // Set last = 1, PRG index = 0
     exp_msg.PAYLOAD = (0x2233UL << 48UL) | (PRGR_RESPONSE_FAILURE << 44UL);
     message_received = 0;
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
     // Send another
     message_received = 0;
-    handle_page_request(&pr);
+    handle_page_request(&iommu, &pr);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
-    write_register(IPSR_OFFSET,4, ipsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET,4, ipsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.pip == 0 ) );
     access_viol_addr = -1;
 
     // disable page queue interrupt
-    pqcsr.raw = read_register(PQCSR_OFFSET, 4);
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
-    write_register(IPSR_OFFSET,4, ipsr.raw);
+    pqcsr.raw = read_register(&iommu, PQCSR_OFFSET, 4);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
+    write_register(&iommu, IPSR_OFFSET,4, ipsr.raw);
 
     pqcsr.pie = 0;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-    handle_page_request(&pr);
-    ipsr.raw = read_register(IPSR_OFFSET, 4);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+    handle_page_request(&iommu, &pr);
+    ipsr.raw = read_register(&iommu, IPSR_OFFSET, 4);
     fail_if( ( ipsr.pip == 1 ) );
     pqcsr.pqen = 0;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
     pqcsr.pqen = 1;
-    write_register(PQCSR_OFFSET, 4, pqcsr.raw);
+    write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
 
     END_TEST();
 
@@ -3292,7 +3295,7 @@ main(void) {
     inv_cc.DSV = 1;
     inv_cc.DSEG = 0x43;
     inv_cc.PAYLOAD = (0x9988UL << 48UL) | (3UL << 32UL) | 0x00000001UL;
-    fail_if( ( handle_invalidation_completion(&inv_cc) == 0 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) == 0 ) );
 
     // send one - itag should be 0
     exp_msg.MSGCODE = INVAL_REQ_MSG_CODE;
@@ -3306,13 +3309,13 @@ main(void) {
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = 0x1234000000000000;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
     // send another - itag should be 1
     exp_msg.TAG = 1;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
@@ -3322,7 +3325,7 @@ main(void) {
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
     pr_go_requested = 0;
     pw_go_requested = 0;
-    iofence(IOFENCE_C, 1, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+    iofence(&iommu, IOFENCE_C, 1, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
     // Fence should not complete
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
@@ -3332,7 +3335,7 @@ main(void) {
     // Send one more - this should get stuck behind the IOFENCE
     exp_msg.TAG = 2;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 1 ) );
     // Fence should still not complete
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
@@ -3351,19 +3354,19 @@ main(void) {
     inv_cc.DSV = 1;
     inv_cc.DSEG = 0x43;
     inv_cc.PAYLOAD = (0x9988UL << 48UL) | (3UL << 32UL) | 0x00000001UL;
-    fail_if( ( handle_invalidation_completion(&inv_cc) != 1 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 1 ) );
     inv_cc.RID = 0x1234;
     inv_cc.DSEG = 0x99;
     // Send a invalid completion with itag of second inval
     inv_cc.PAYLOAD = (0x9988UL << 48UL) | (3UL << 32UL) | 0x00000002UL;
-    fail_if( ( handle_invalidation_completion(&inv_cc) != 1 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 1 ) );
 
     // Send completion for second itag with 3 completions
     inv_cc.RID = 0x1234;
     inv_cc.DSEG = 0x43;
     inv_cc.PAYLOAD = (0x9988UL << 48UL) | (3UL << 32UL) | 0x00000002UL;
     for ( i = 0; i < 3; i++ ) {
-        fail_if( ( handle_invalidation_completion(&inv_cc) != 0 ) );
+        fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 0 ) );
         // Fence should still not complete
         read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
         fail_if( ( iofence_data != 0x1234567812345678 )  );
@@ -3376,7 +3379,7 @@ main(void) {
     inv_cc.DSEG = 0x43;
     inv_cc.PAYLOAD = (0x9988UL << 48UL) | (0UL << 32UL) | 0x00000001UL;
     for ( i = 0; i < 7; i++ ) {
-        fail_if( ( handle_invalidation_completion(&inv_cc) != 0 ) );
+        fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 0 ) );
         // Fence should still not complete
         read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
         fail_if( ( iofence_data != 0x1234567812345678 )  );
@@ -3385,7 +3388,7 @@ main(void) {
     }
 
     // Send the 8th one
-    fail_if( ( handle_invalidation_completion(&inv_cc) != 0 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 0 ) );
     // Fence should complete
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x12345678deadbeef )  );
@@ -3396,7 +3399,7 @@ main(void) {
     // The pending one should come out and with tag of 0 on next clock
     exp_msg.TAG = 0;
     message_received = 0;
-    process_commands();
+    process_commands(&iommu);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
@@ -3405,68 +3408,68 @@ main(void) {
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
     pr_go_requested = 0;
     pw_go_requested = 0;
-    iofence(IOFENCE_C, 1, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+    iofence(&iommu, IOFENCE_C, 1, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
     // Fence should not complete
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( pr_go_requested == 1) );
     fail_if( ( pw_go_requested == 1) );
 
-    i = read_register(CQH_OFFSET, 4);
+    i = read_register(&iommu, CQH_OFFSET, 4);
 
     // Make it timeout
-    do_ats_timer_expiry(0x00000001);
+    do_ats_timer_expiry(&iommu, 0x00000001);
     // Command queue should timeout
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_to != 1 ) );
     // Queue a command - should not be picked up
     // head register must not move
-    iodir(INVAL_DDT, 1, 0x112233, 0);
-    fail_if( ( i != read_register(CQH_OFFSET, 4) ) );
+    iodir(&iommu, INVAL_DDT, 1, 0x112233, 0);
+    fail_if( ( i != read_register(&iommu, CQH_OFFSET, 4) ) );
 
     // clear the cmd_to bit
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
     // clean up the command queue
-    write_register(CQT_OFFSET, 4, i);
+    write_register(&iommu, CQT_OFFSET, 4, i);
 
     // test running out of itags
     exp_msg.TAG = 0;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
     exp_msg.TAG = 1;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
     // Next two should block
     exp_msg.TAG = 1;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 1 ) );
     exp_msg.TAG = 0;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 1 ) );
 
     // Complete first two
     inv_cc.PAYLOAD = (0x1234UL << 48UL) | (2UL << 32UL) | 0x00000003UL;
-    fail_if( ( handle_invalidation_completion(&inv_cc) != 0 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 0 ) );
     fail_if( ( message_received == 1 ) );
-    fail_if( ( handle_invalidation_completion(&inv_cc) != 0 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 0 ) );
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
     message_received = 0;
     exp_msg.TAG = 1;
-    process_commands();
+    process_commands(&iommu);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
     // Complete next two
     inv_cc.PAYLOAD = (0x1234UL << 48UL) | (1UL << 32UL) | 0x00000003UL;
-    fail_if( ( handle_invalidation_completion(&inv_cc) != 0 ) );
+    fail_if( ( handle_invalidation_completion(&iommu, &inv_cc) != 0 ) );
 
     // Test turning off command queue while IOFENCE is pending
     // send one - itag should be 0
@@ -3481,7 +3484,7 @@ main(void) {
     exp_msg.DSEG = 0x43;
     exp_msg.PAYLOAD = 0x1234000000000000;
     message_received = 0;
-    ats_command(INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
+    ats_command(&iommu, INVAL, 1, 0, 0, 0x43, 0x1234, 0x1234000000000000);
     fail_if( ( message_received == 0 ) );
     fail_if( ( exp_msg_received == 0 ) );
 
@@ -3491,41 +3494,41 @@ main(void) {
     write_memory_test((char *)&iofence_data, (iofence_PPN * PAGESIZE), 8);
     pr_go_requested = 0;
     pw_go_requested = 0;
-    iofence(IOFENCE_C, 1, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
+    iofence(&iommu, IOFENCE_C, 1, 1, 1, 0, (iofence_PPN * PAGESIZE), 0xDEADBEEF);
     // Fence should not complete
     read_memory_test((iofence_PPN * PAGESIZE), 8, (char *)&iofence_data);
     fail_if( ( iofence_data != 0x1234567812345678 )  );
     fail_if( ( pr_go_requested == 1) );
     fail_if( ( pw_go_requested == 1) );
 
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
 
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 1 ) );
     fail_if( ( cqcsr.cqen != 0 ) );
     fail_if( ( cqcsr.busy != 1 ) );
 
     // Make it timeout
-    do_ats_timer_expiry(0x00000001);
+    do_ats_timer_expiry(&iommu, 0x00000001);
 
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 0 ) );
     fail_if( ( cqcsr.cqen != 0 ) );
     fail_if( ( cqcsr.busy != 0 ) );
 
     cqcsr.cqen = 1;
     cqcsr.cmd_to = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
-    i = read_register(CQH_OFFSET, 4);
-    write_register(CQT_OFFSET, 4, i);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
+    i = read_register(&iommu, CQH_OFFSET, 4);
+    write_register(&iommu, CQT_OFFSET, 4, i);
     END_TEST();
 
     START_TEST("MSI write-through mode");
 
-    DC_addr = add_device(0x042874, 0x1974, 1, 0, 0, 0, 0,
+    DC_addr = add_device(&iommu, 0x042874, 0x1974, 1, 0, 0, 0, 0,
                          1, 1, 0, 0, 0,
                          IOHGATP_Sv48x4, IOSATP_Bare, PDTP_Bare,
                          MSIPTP_Flat, 1, 0x0000000FF, 0x280000000);
@@ -3534,96 +3537,96 @@ main(void) {
 
     // Cause a access violation
     access_viol_addr = (DC.msiptp.PPN * PAGESIZE) + 3 * 16;
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 261, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 261, 0) < 0 ) );
     access_viol_addr = -1;
 
     data_corruption_addr = (DC.msiptp.PPN * PAGESIZE) + 3 * 16;
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 270, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 270, 0) < 0 ) );
     data_corruption_addr = -1;
 
     // Not present
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 262, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 262, 0) < 0 ) );
 
     // Misconfigured
     msipte_t msipte;
     msipte.V = 1;
     msipte.M = 0x0;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
 
     msipte.C = 1;
     msipte.M = 0x0;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
 
     msipte.C = 0;
     msipte.M = 2;
     msipte.translate_rw.reserved = 0x1;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
     msipte.translate_rw.reserved = 0x0;
     msipte.translate_rw.reserved = 0x4;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
 
     msipte.C = 0;
     msipte.M = 0x3;
     msipte.translate_rw.reserved = 0x1;
     msipte.translate_rw.reserved0 = 0x0;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
     msipte.translate_rw.reserved = 0x0;
     msipte.translate_rw.reserved = 0x4;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
 
     msipte.C = 0;
     msipte.M = 0x3;
     msipte.translate_rw.reserved = 0x0;
     msipte.translate_rw.reserved0 = 0x1;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
     msipte.translate_rw.reserved = 0x0;
     msipte.translate_rw.reserved = 0x4;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
 
     msipte.C = 0;
     msipte.M = 0x3;
     msipte.translate_rw.reserved = 0x1;
     msipte.translate_rw.reserved0 = 0x1;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
     msipte.translate_rw.reserved = 0x0;
     msipte.translate_rw.reserved = 0x4;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0) );
 
     // Write through PTE
     msipte.translate_rw.reserved = 0x0;
@@ -3631,9 +3634,9 @@ main(void) {
     msipte.translate_rw.M = 0x3;
     msipte.translate_rw.PPN = 0xdeadbeef;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != 0xdeadbeef ) );
     fail_if( ( rsp.trsp.is_msi != 1 ) );
     fail_if( ( rsp.trsp.S != 0 ) );
@@ -3644,9 +3647,9 @@ main(void) {
     // corrupt but hit from cache
     msipte.translate_rw.reserved = 0x1;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != 0xdeadbeef ) );
     fail_if( ( rsp.trsp.is_msi != 1 ) );
     fail_if( ( rsp.trsp.S != 0 ) );
@@ -3655,10 +3658,10 @@ main(void) {
     fail_if( ( rsp.trsp.is_mrif != 0 ) );
 
     // Invalidate TLB
-    iotinval(GVMA, 1, 1, 0, 0x1974, 0, gpa);
-    send_translation_request(0x042874, 0, 0x0000, 0,
+    iotinval(&iommu, GVMA, 1, 1, 0, 0x1974, 0, gpa);
+    send_translation_request(&iommu, 0x042874, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
     msipte.translate_rw.reserved = 0x1;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 3 * 16), 16);
     msipte.translate_rw.reserved = 0x0;
@@ -3669,16 +3672,16 @@ main(void) {
     DC.tc.PDTV = 1;
     DC.fsc.pdtp.MODE = 0;
     write_memory_test((char *)&DC, DC_addr, 64);
-    iodir(INVAL_DDT, 1, 0x042874, 0);
-    send_translation_request(0x042874, 1, 0xBABEC, 0,
+    iodir(&iommu, INVAL_DDT, 1, 0x042874, 0);
+    send_translation_request(&iommu, 0x042874, 1, 0xBABEC, 0,
              1, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa,
              1, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 1, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 1, 0) < 0 ) );
 
     // Execute permission request using translation request
-    send_translation_request(0x042874, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x042874, 1, 0xBABEC, 0,
              1, 0, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gpa, 4, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.U == 1 ) );
     fail_if( ( rsp.trsp.R != 1 ) );
     fail_if( ( rsp.trsp.W != 1 ) );
@@ -3687,7 +3690,7 @@ main(void) {
     END_TEST();
 
     START_TEST("MSI MFIF mode");
-    DC_addr = add_device(0x121679, 0x1979, 1, 0, 0, 0, 0,
+    DC_addr = add_device(&iommu, 0x121679, 0x1979, 1, 0, 0, 0, 0,
                          1, 1, 0, 0, 0,
                          IOHGATP_Sv48x4, IOSATP_Bare, PDTP_Bare,
                          MSIPTP_Flat, 1, 0x0000000FF, 0x280000000);
@@ -3709,33 +3712,33 @@ main(void) {
     gpa = 0x280000023000;
 
     // Disable MRIF
-    g_reg_file.capabilities.msi_mrif = 0;
-    send_translation_request(0x121679, 0, 0x0000, 0,
+    iommu.reg_file.capabilities.msi_mrif = 0;
+    send_translation_request(&iommu, 0x121679, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
-    g_reg_file.capabilities.msi_mrif = 1;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    iommu.reg_file.capabilities.msi_mrif = 1;
 
     // misconfigured
     msipte.mrif.reserved1 = 1;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 0x23 * 16), 16);
-    send_translation_request(0x121679, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x121679, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 263, 0) < 0 ) );
     msipte.mrif.reserved1 = 0;
     write_memory_test((char *)&msipte, ((DC.msiptp.PPN * PAGESIZE) + 0x23 * 16), 16);
 
     // Unsupported
-    send_translation_request(0x121679, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x121679, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_PCIE_ATS_TRANSLATION_REQUEST, gpa, 4, READ, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.U != 1 ) );
     fail_if( ( rsp.trsp.R != 1 ) );
     fail_if( ( rsp.trsp.W != 1 ) );
 
     // Success
-    send_translation_request(0x121679, 0, 0x0000, 0,
+    send_translation_request(&iommu, 0x121679, 0, 0x0000, 0,
              0, 0, 0, ADDR_TYPE_UNTRANSLATED, gpa, 4, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
     fail_if( ( rsp.trsp.PPN != 0xdeadbeef ) );
     fail_if( ( rsp.trsp.S != 0 ) );
     fail_if( ( rsp.trsp.PBMT != PMA ) );
@@ -3760,11 +3763,11 @@ main(void) {
     tr_req_ctrl.NW = 1;
     tr_req_ctrl.go_busy = 1;
     tr_req_iova.raw = gpa;
-    write_register(TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
-    write_register(TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
-    tr_response.raw = read_register(TR_RESPONSE_OFFSET, 8);
+    write_register(&iommu, TR_REQ_IOVA_OFFSET, 8, tr_req_iova.raw);
+    write_register(&iommu, TR_REQ_CTRL_OFFSET, 8, tr_req_ctrl.raw);
+    tr_response.raw = read_register(&iommu, TR_RESPONSE_OFFSET, 8);
     fail_if( ( tr_response.fault == 0 ) );
-    fail_if( ( check_faults(260, tr_req_ctrl.PV, tr_req_ctrl.PID, tr_req_ctrl.Priv, 0x121679, gpa, UNTRANSLATED_READ_TRANSACTION, 0) < 0 ) );
+    fail_if( ( check_faults(&iommu, 260, tr_req_ctrl.PV, tr_req_ctrl.PID, tr_req_ctrl.Priv, 0x121679, gpa, UNTRANSLATED_READ_TRANSACTION, 0) < 0 ) );
 
     END_TEST();
 
@@ -3772,15 +3775,15 @@ main(void) {
     // illegal command
     cmd.any.opcode = 9;
     cmd.any.func3 = 0;
-    generic_any(cmd);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    generic_any(&iommu, cmd);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 1 ) );
     fail_if( ( cqcsr.cmd_ill != 0 ) );
 
@@ -3861,15 +3864,15 @@ main(void) {
             if ( cmd.any.opcode == ATS && cmd.ats.rsvd == 0 &&
                  cmd.ats.rsvd1 == 0)
                 cmd.ats.func3 = 0x7;
-            generic_any(cmd);
-            cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+            generic_any(&iommu, cmd);
+            cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
             fail_if( ( cqcsr.cmd_ill != 1 ) );
             cqcsr.cqen = 0;
-            write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-            write_register(CQT_OFFSET, 4, 0);
+            write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+            write_register(&iommu, CQT_OFFSET, 4, 0);
             cqcsr.cqen = 1;
-            write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-            cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+            write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+            cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
             fail_if( ( cqcsr.cqon != 1 ) );
             fail_if( ( cqcsr.cmd_ill != 0 ) );
         }
@@ -3878,78 +3881,78 @@ main(void) {
     cmd.low = 0;
     cmd.any.opcode = IODIR;
     cmd.any.func3 = 7;
-    generic_any(cmd);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    generic_any(&iommu, cmd);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 1 ) );
     fail_if( ( cqcsr.cmd_ill != 0 ) );
 
     // too wide device ID to IODIR.INVAL_DDT
-    g_max_devid_mask = 0x3F;
-    iodir(INVAL_DDT, 1, 0x012345, 0);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iommu.max_devid_mask = 0x3F;
+    iodir(&iommu, INVAL_DDT, 1, 0x012345, 0);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 1 ) );
     fail_if( ( cqcsr.cmd_ill != 0 ) );
-    g_max_devid_mask = 0xFFFFFF;
+    iommu.max_devid_mask = 0xFFFFFF;
 
     // too wide pasid to iodir.inval_pdt
-    g_reg_file.capabilities.pd20 = 0;
-    iodir(INVAL_PDT, 1, 0x112233, 0xBABEC);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iommu.reg_file.capabilities.pd20 = 0;
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBABEC);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 1 ) );
     fail_if( ( cqcsr.cmd_ill != 0 ) );
-    g_reg_file.capabilities.pd17 = 0;
-    iodir(INVAL_PDT, 1, 0x112233, 0xBEC);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iommu.reg_file.capabilities.pd17 = 0;
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBEC);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 1 ) );
     cqcsr.cqen = 0;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    write_register(CQT_OFFSET, 4, 0);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
     cqcsr.cqen = 1;
-    write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cqon != 1 ) );
     fail_if( ( cqcsr.cmd_ill != 0 ) );
-    g_reg_file.capabilities.pd20 = 1;
-    g_reg_file.capabilities.pd17 = 1;
-    iodir(INVAL_PDT, 1, 0x112233, 0xBABEC);
-    cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+    iommu.reg_file.capabilities.pd20 = 1;
+    iommu.reg_file.capabilities.pd17 = 1;
+    iodir(&iommu, INVAL_PDT, 1, 0x112233, 0xBABEC);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 0 ) );
 
     // idle
-    process_commands();
+    process_commands(&iommu);
 
     END_TEST();
 
     START_TEST("Sv32 mode");
     // Change IOMMU mode to base device context
-    g_reg_file.capabilities.msi_flat = 0;
+    iommu.reg_file.capabilities.msi_flat = 0;
 
     // Allow selection of Sv32
-    g_gxl_writeable = 1;
-    g_reg_file.fctl.gxl = 1;
+    iommu.gxl_writeable = 1;
+    iommu.reg_file.fctl.gxl = 1;
 
-    DC_addr = add_device(0x000000, 1, 0, 0, 0, 0, 0,
+    DC_addr = add_device(&iommu, 0x000000, 1, 0, 0, 0, 0, 0,
                          1, 1, 0, 0, 1,
                          IOHGATP_Sv32x4, IOSATP_Bare, PD20,
                          MSIPTP_Flat, 1, 0xFFFFFFFFFF, 0x1000000000);
@@ -3970,12 +3973,12 @@ main(void) {
     gpte.D = 0;
     gpte.PBMT = PMA;
     gpte.PPN = get_free_ppn(1);
-    add_g_stage_pte(DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
+    add_g_stage_pte(&iommu, DC.iohgatp, (PC.fsc.iosatp.PPN * PAGESIZE), gpte, 0);
     PC.ta.V = 1;
     PC.ta.PSCID = 10;
     PC.ta.ENS = 1;
     PC.ta.SUM = 1;
-    PC_addr = add_process_context(&DC, &PC, 0xBABEC);
+    PC_addr = add_process_context(&iommu, &DC, &PC, 0xBABEC);
     read_memory_test(PC_addr, 16, (char *)&PC);
 
     pte.raw = 0;
@@ -4003,13 +4006,13 @@ main(void) {
     gpte.PPN = get_free_ppn(1);
     gpa = pte.PPN * PAGESIZE;
     spa = gpte.PPN * PAGESIZE;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 0);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 0);
     gva = 0x100000;
-    pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
-    send_translation_request(0x000000, 1, 0xBABEC, 0,
+    pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 0, DC.iohgatp, DC.tc.SXL);
+    send_translation_request(&iommu, 0x000000, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
 
 
     // Make a large page PTE
@@ -4017,41 +4020,41 @@ main(void) {
     gpte.PPN = get_free_ppn(1024);
     gpa = pte.PPN * PAGESIZE;
     spa = gpte.PPN * PAGESIZE;
-    gpte_addr = add_g_stage_pte(DC.iohgatp, gpa, gpte, 1);
+    gpte_addr = add_g_stage_pte(&iommu, DC.iohgatp, gpa, gpte, 1);
     gva = 0x19000000;
-    pte_addr = add_vs_stage_pte(PC.fsc.iosatp, gva, pte, 1, DC.iohgatp, DC.tc.SXL);
-    send_translation_request(0x000000, 1, 0xBABEC, 0,
+    pte_addr = add_vs_stage_pte(&iommu, PC.fsc.iosatp, gva, pte, 1, DC.iohgatp, DC.tc.SXL);
+    send_translation_request(&iommu, 0x000000, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, gva,
              1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, SUCCESS, 0, 0) < 0 ) );
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, SUCCESS, 0, 0) < 0 ) );
 
     // Invalid first stage modes
-    iodir(INVAL_DDT, 1, 0x000000, 0);
-    iodir(INVAL_PDT, 1, 0x000000, 0xBABEC);
+    iodir(&iommu, INVAL_DDT, 1, 0x000000, 0);
+    iodir(&iommu, INVAL_PDT, 1, 0x000000, 0xBABEC);
     for ( j = 1; j < 16; j++ ) {
         if (j == 8) continue;
         PC.fsc.iosatp.MODE = j;
         write_memory_test((char *)&PC, PC_addr, 16);
-        send_translation_request(0x000000, 1, 0xBABEC, 0,
+        send_translation_request(&iommu, 0x000000, 1, 0xBABEC, 0,
              0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
              1, WRITE, &req, &rsp);
-        fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+        fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
     }
 
-    g_reg_file.capabilities.Sv32 = 0;
+    iommu.reg_file.capabilities.Sv32 = 0;
     PC.fsc.iosatp.MODE = IOSATP_Sv32;
     write_memory_test((char *)&PC, PC_addr, 16);
-    send_translation_request(0x000000, 1, 0xBABEC, 0,
+    send_translation_request(&iommu, 0x000000, 1, 0xBABEC, 0,
          0, 1, 0, ADDR_TYPE_UNTRANSLATED, 0xdeadbeef,
          1, WRITE, &req, &rsp);
-    fail_if( ( check_rsp_and_faults(&req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
-    g_reg_file.capabilities.Sv32 = 1;
+    fail_if( ( check_rsp_and_faults(&iommu, &req, &rsp, UNSUPPORTED_REQUEST, 267, 0) < 0 ) );
+    iommu.reg_file.capabilities.Sv32 = 1;
 
     PC.fsc.iosatp.MODE = IOSATP_Sv48;
     write_memory_test((char *)&PC, PC_addr, 16);
 
-    g_gxl_writeable = 1;
-    g_reg_file.fctl.gxl = 1;
+    iommu.gxl_writeable = 1;
+    iommu.reg_file.fctl.gxl = 1;
 
     END_TEST();
 
@@ -4063,97 +4066,97 @@ main(void) {
         switch (offset) {
             case CAPABILITIES_OFFSET:
                 // This register is read only
-                temp = read_register(i, 8);
-                write_register(i, 8, 0xFF);
-                fail_if( ( temp != read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                write_register(&iommu, i, 8, 0xFF);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
             case FCTRL_OFFSET:
-                fctl.raw = read_register(i, 4);
+                fctl.raw = read_register(&iommu, i, 4);
                 fctl.be = 1;
                 fctl.wsi = 1;
-                write_register(i, 4, fctl.raw);
-                fctl.raw = read_register(i, 4);
+                write_register(&iommu, i, 4, fctl.raw);
+                fctl.raw = read_register(&iommu, i, 4);
                 fail_if( ( fctl.be != 0 ) );
                 fail_if( ( fctl.wsi != 0 ) );
-                g_reg_file.capabilities.end = BOTH_END;
-                fctl.raw = read_register(i, 4);
+                iommu.reg_file.capabilities.end = BOTH_END;
+                fctl.raw = read_register(&iommu, i, 4);
                 temp = fctl.raw;
                 fail_if( ( fctl.be != 0 ) );
                 fail_if( ( fctl.wsi != 0 ) );
                 // IOMMU is on - this register should not be writeable
                 fctl.be = 1;
                 fctl.wsi = 1;
-                write_register(i, 4, fctl.raw);
-                fail_if( ( temp != read_register(i, 4) ) );
-                fail_if( ( enable_iommu(Off) < 0 ) );
+                write_register(&iommu, i, 4, fctl.raw);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
+                fail_if( ( enable_iommu(&iommu, Off) < 0 ) );
                 // QUeues are On - register must not be writeable
-                write_register(i, 4, fctl.raw);
-                fail_if( ( temp != read_register(i, 4) ) );
-                pqcsr.raw = read_register(PQCSR_OFFSET, 4);
+                write_register(&iommu, i, 4, fctl.raw);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
+                pqcsr.raw = read_register(&iommu, PQCSR_OFFSET, 4);
                 pqcsr.pqen = 0;
-                write_register(PQCSR_OFFSET, 4, pqcsr.raw);
-                write_register(i, 4, fctl.raw);
-                fail_if( ( temp != read_register(i, 4) ) );
-                fqcsr.raw = read_register(FQCSR_OFFSET, 4);
+                write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
+                write_register(&iommu, i, 4, fctl.raw);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
+                fqcsr.raw = read_register(&iommu, FQCSR_OFFSET, 4);
                 fqcsr.fqen = 0;
-                write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-                write_register(i, 4, fctl.raw);
-                fail_if( ( temp != read_register(i, 4) ) );
-                cqcsr.raw = read_register(CQCSR_OFFSET, 4);
+                write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+                write_register(&iommu, i, 4, fctl.raw);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
+                cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
                 cqcsr.cqen = 0;
-                write_register(CQCSR_OFFSET, 4, cqcsr.raw);
-                write_register(CQT_OFFSET, 4, 0);
-                write_register(i, 4, fctl.raw);
-                fctl.raw = read_register(i, 4);
+                write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+                write_register(&iommu, CQT_OFFSET, 4, 0);
+                write_register(&iommu, i, 4, fctl.raw);
+                fctl.raw = read_register(&iommu, i, 4);
                 fail_if( ( fctl.be != 1 ) );
                 fail_if( ( fctl.wsi != 0 ) );
-                g_reg_file.capabilities.igs = IGS_BOTH;
+                iommu.reg_file.capabilities.igs = IGS_BOTH;
                 fctl.wsi = 1;
-                write_register(i, 4, fctl.raw);
-                fctl.raw = read_register(i, 4);
+                write_register(&iommu, i, 4, fctl.raw);
+                fctl.raw = read_register(&iommu, i, 4);
                 fail_if( ( fctl.wsi != 1 ) );
 
                 fctl.be = 0;
                 fctl.wsi = 0;
-                write_register(i, 4, fctl.raw);
+                write_register(&iommu, i, 4, fctl.raw);
                 pqcsr.pqen = 1;
-                write_register(PQCSR_OFFSET, 4, pqcsr.raw);
+                write_register(&iommu, PQCSR_OFFSET, 4, pqcsr.raw);
                 cqcsr.cqen = 1;
-                write_register(CQCSR_OFFSET, 4, cqcsr.raw);
+                write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
                 fqcsr.fqen = 1;
-                write_register(FQCSR_OFFSET, 4, fqcsr.raw);
-                fail_if( ( enable_iommu(Off) < 0 ) );
-                fail_if( ( enable_iommu(DDT_3LVL) < 0 ) );
+                write_register(&iommu, FQCSR_OFFSET, 4, fqcsr.raw);
+                fail_if( ( enable_iommu(&iommu, Off) < 0 ) );
+                fail_if( ( enable_iommu(&iommu, DDT_3LVL) < 0 ) );
                 // test that writes to ddtp when it is busy are discarded
-                g_reg_file.ddtp.busy = 1;
+                iommu.reg_file.ddtp.busy = 1;
                 ddtp.iommu_mode = Off;
-                write_register(DDTP_OFFSET, 8, ddtp.raw);
-                ddtp.raw = read_register(DDTP_OFFSET, 8);
-                g_reg_file.ddtp.busy = 0;
+                write_register(&iommu, DDTP_OFFSET, 8, ddtp.raw);
+                ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
+                iommu.reg_file.ddtp.busy = 0;
                 fail_if( (ddtp.iommu_mode != DDT_3LVL) );
                 offset += 4;
                 break;
             case DDTP_OFFSET:
-                ddtp.raw = read_register(DDTP_OFFSET, 8);
+                ddtp.raw = read_register(&iommu, DDTP_OFFSET, 8);
                 fail_if( (ddtp.iommu_mode != DDT_3LVL ) );
                 offset += 8;
                 break;
             case CQB_OFFSET:
             case FQB_OFFSET:
             case PQB_OFFSET:
-                temp = read_register(i, 8);
-                write_register(i, 8, 0xFF);
-                fail_if( ( temp != read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                write_register(&iommu, i, 8, 0xFF);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
             case FQT_OFFSET:
             case CQH_OFFSET:
             case PQT_OFFSET:
             case IOCNTOVF_OFFSET:
-                temp = read_register(i, 4);
-                write_register(i, 4, 0xFF);
-                fail_if( ( temp != read_register(i, 4) ) );
+                temp = read_register(&iommu, i, 4);
+                write_register(&iommu, i, 4, 0xFF);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
                 offset += 4;
                 break;
             case FQH_OFFSET:
@@ -4169,13 +4172,13 @@ main(void) {
                 offset += 4;
                 break;
             case IOHPMCYCLES_OFFSET:
-                temp = read_register(i, 8);
-                g_reg_file.capabilities.hpm = 0;
-                write_register(i, 8, temp + 1);
-                fail_if( ( temp != read_register(i, 8) ) );
-                g_reg_file.capabilities.hpm = 1;
-                write_register(i, 8, temp + 1);
-                fail_if( ( (temp + 1) != read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                iommu.reg_file.capabilities.hpm = 0;
+                write_register(&iommu, i, 8, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
+                iommu.reg_file.capabilities.hpm = 1;
+                write_register(&iommu, i, 8, temp + 1);
+                fail_if( ( (temp + 1) != read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
             case IOHPMCTR1_OFFSET:
@@ -4209,16 +4212,16 @@ main(void) {
             case IOHPMCTR29_OFFSET:
             case IOHPMCTR30_OFFSET:
             case IOHPMCTR31_OFFSET:
-                temp = read_register(i, 8);
-                g_reg_file.capabilities.hpm = 0;
-                write_register(i, 8, temp + 1);
-                fail_if( ( temp != read_register(i, 8) ) );
-                g_reg_file.capabilities.hpm = 1;
-                write_register(i, 8, temp + 1);
+                temp = read_register(&iommu, i, 8);
+                iommu.reg_file.capabilities.hpm = 0;
+                write_register(&iommu, i, 8, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
+                iommu.reg_file.capabilities.hpm = 1;
+                write_register(&iommu, i, 8, temp + 1);
                 if ( offset < IOHPMCTR8_OFFSET ) {
-                    fail_if( ( (temp + 1) != read_register(i, 8) ) );
+                    fail_if( ( (temp + 1) != read_register(&iommu, i, 8) ) );
                 } else {
-                    fail_if( ( (temp) != read_register(i, 8) ) );
+                    fail_if( ( (temp) != read_register(&iommu, i, 8) ) );
                 }
                 offset += 8;
                 break;
@@ -4253,35 +4256,35 @@ main(void) {
             case IOHPMEVT29_OFFSET:
             case IOHPMEVT30_OFFSET:
             case IOHPMEVT31_OFFSET:
-                temp = read_register(i, 8);
-                g_reg_file.capabilities.hpm = 0;
-                write_register(i, 8, temp + 1);
-                fail_if( ( temp != read_register(i, 8) ) );
-                g_reg_file.capabilities.hpm = 1;
-                write_register(i, 8, temp + 1);
+                temp = read_register(&iommu, i, 8);
+                iommu.reg_file.capabilities.hpm = 0;
+                write_register(&iommu, i, 8, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
+                iommu.reg_file.capabilities.hpm = 1;
+                write_register(&iommu, i, 8, temp + 1);
                 if ( offset < IOHPMEVT8_OFFSET ) {
-                    fail_if( ( (temp + 1) != read_register(i, 8) ) );
+                    fail_if( ( (temp + 1) != read_register(&iommu, i, 8) ) );
                 } else {
-                    fail_if( ( (temp) != read_register(i, 8) ) );
+                    fail_if( ( (temp) != read_register(&iommu, i, 8) ) );
                 }
                 offset += 8;
                 break;
 
             case TR_REQ_IOVA_OFFSET:
             case TR_REQ_CTRL_OFFSET:
-                temp = read_register(i, 8);
-                g_reg_file.capabilities.dbg = 0;
-                write_register(i, 8, temp + 8192);
-                fail_if( ( temp != read_register(i, 8) ) );
-                g_reg_file.capabilities.dbg = 1;
-                write_register(i, 8, temp + 8192);
-                fail_if( ( (temp + 8192) != read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                iommu.reg_file.capabilities.dbg = 0;
+                write_register(&iommu, i, 8, temp + 8192);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
+                iommu.reg_file.capabilities.dbg = 1;
+                write_register(&iommu, i, 8, temp + 8192);
+                fail_if( ( (temp + 8192) != read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
             case TR_RESPONSE_OFFSET:
-                temp = read_register(i, 8);
-                write_register(i, 8, temp + 1);
-                fail_if( ( temp != read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                write_register(&iommu, i, 8, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
 
@@ -4296,13 +4299,13 @@ main(void) {
             case MSI_ADDR_5_OFFSET:
             case MSI_ADDR_6_OFFSET:
             case MSI_ADDR_7_OFFSET:
-                temp = read_register(i, 8);
-                g_reg_file.capabilities.igs = WSI;
-                write_register(i, 8, temp + 8);
-                fail_if( ( temp != read_register(i, 8) ) );
-                g_reg_file.capabilities.igs = 0;
-                write_register(i, 8, temp + 8);
-                fail_if( ( (temp + 8) != read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                iommu.reg_file.capabilities.igs = WSI;
+                write_register(&iommu, i, 8, temp + 8);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
+                iommu.reg_file.capabilities.igs = 0;
+                write_register(&iommu, i, 8, temp + 8);
+                fail_if( ( (temp + 8) != read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
             case MSI_ADDR_8_OFFSET:
@@ -4313,13 +4316,13 @@ main(void) {
             case MSI_ADDR_13_OFFSET:
             case MSI_ADDR_14_OFFSET:
             case MSI_ADDR_15_OFFSET:
-                temp = read_register(i, 8);
-                g_reg_file.capabilities.igs = WSI;
-                write_register(i, 8, temp + 8);
-                fail_if( ( temp != read_register(i, 8) ) );
-                g_reg_file.capabilities.igs = 0;
-                write_register(i, 8, temp + 8);
-                fail_if( ( (temp + 8) == read_register(i, 8) ) );
+                temp = read_register(&iommu, i, 8);
+                iommu.reg_file.capabilities.igs = WSI;
+                write_register(&iommu, i, 8, temp + 8);
+                fail_if( ( temp != read_register(&iommu, i, 8) ) );
+                iommu.reg_file.capabilities.igs = 0;
+                write_register(&iommu, i, 8, temp + 8);
+                fail_if( ( (temp + 8) == read_register(&iommu, i, 8) ) );
                 offset += 8;
                 break;
             case MSI_DATA_0_OFFSET:
@@ -4338,14 +4341,14 @@ main(void) {
             case MSI_VEC_CTRL_5_OFFSET:
             case MSI_VEC_CTRL_6_OFFSET:
             case MSI_VEC_CTRL_7_OFFSET:
-                write_register(i, 4, 0);
-                temp = read_register(i, 4);
-                g_reg_file.capabilities.igs = WSI;
-                write_register(i, 4, temp + 1);
-                fail_if( ( temp != read_register(i, 4) ) );
-                g_reg_file.capabilities.igs = 0;
-                write_register(i, 4, temp + 1);
-                fail_if( ( (temp + 1) != read_register(i, 4) ) );
+                write_register(&iommu, i, 4, 0);
+                temp = read_register(&iommu, i, 4);
+                iommu.reg_file.capabilities.igs = WSI;
+                write_register(&iommu, i, 4, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
+                iommu.reg_file.capabilities.igs = 0;
+                write_register(&iommu, i, 4, temp + 1);
+                fail_if( ( (temp + 1) != read_register(&iommu, i, 4) ) );
                 offset += 4;
                 break;
             case MSI_DATA_8_OFFSET:
@@ -4364,69 +4367,69 @@ main(void) {
             case MSI_VEC_CTRL_13_OFFSET:
             case MSI_VEC_CTRL_14_OFFSET:
             case MSI_VEC_CTRL_15_OFFSET:
-                write_register(i, 4, 0);
-                temp = read_register(i, 4);
-                g_reg_file.capabilities.igs = WSI;
-                write_register(i, 4, temp + 1);
-                fail_if( ( temp != read_register(i, 4) ) );
-                g_reg_file.capabilities.igs = 0;
-                write_register(i, 4, temp + 1);
-                fail_if( ( (temp + 1) == read_register(i, 4) ) );
+                write_register(&iommu, i, 4, 0);
+                temp = read_register(&iommu, i, 4);
+                iommu.reg_file.capabilities.igs = WSI;
+                write_register(&iommu, i, 4, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
+                iommu.reg_file.capabilities.igs = 0;
+                write_register(&iommu, i, 4, temp + 1);
+                fail_if( ( (temp + 1) == read_register(&iommu, i, 4) ) );
                 offset += 4;
                 break;
             default:
-                temp = read_register(i, 4);
-                write_register(i, 4, temp + 1);
-                fail_if( ( temp != read_register(i, 4) ) );
+                temp = read_register(&iommu, i, 4);
+                write_register(&iommu, i, 4, temp + 1);
+                fail_if( ( temp != read_register(&iommu, i, 4) ) );
                 offset += 1;
                 break;
         }
     }
     // writing as two 4B writes
-    write_register(MSI_ADDR_0_OFFSET, 4, 0xDEADBEE0);
-    write_register(MSI_ADDR_0_OFFSET+4, 4, 0x000000F0);
-    temp = read_register(MSI_ADDR_0_OFFSET, 8);
+    write_register(&iommu, MSI_ADDR_0_OFFSET, 4, 0xDEADBEE0);
+    write_register(&iommu, MSI_ADDR_0_OFFSET+4, 4, 0x000000F0);
+    temp = read_register(&iommu, MSI_ADDR_0_OFFSET, 8);
     fail_if( ( temp != 0x000000F0DEADBEE0 ) );
 
     // Misaligned access
-    temp1 = read_register(FQCSR_OFFSET, 4);
-    write_register(FQCSR_OFFSET, 8, 0);
-    fail_if( ( temp1 != read_register(FQCSR_OFFSET, 4) ) );
-    temp1 = read_register(FQCSR_OFFSET, 8);
+    temp1 = read_register(&iommu, FQCSR_OFFSET, 4);
+    write_register(&iommu, FQCSR_OFFSET, 8, 0);
+    fail_if( ( temp1 != read_register(&iommu, FQCSR_OFFSET, 4) ) );
+    temp1 = read_register(&iommu, FQCSR_OFFSET, 8);
     fail_if( ( temp1 != 0) );
-    temp1 = read_register(FQCSR_OFFSET, 3);
+    temp1 = read_register(&iommu, FQCSR_OFFSET, 3);
     fail_if( ( temp1 != 0) );
 
     // DIsable ATS only registers
-    g_reg_file.capabilities.ats = 0;
-    g_reg_file.capabilities.hpm = 0;
+    iommu.reg_file.capabilities.ats = 0;
+    iommu.reg_file.capabilities.hpm = 0;
 
-    temp = read_register(PQB_OFFSET, 8);
-    write_register(PQB_OFFSET, 8, temp + 1);
-    fail_if( ( temp != read_register(PQB_OFFSET, 8) ) );
+    temp = read_register(&iommu, PQB_OFFSET, 8);
+    write_register(&iommu, PQB_OFFSET, 8, temp + 1);
+    fail_if( ( temp != read_register(&iommu, PQB_OFFSET, 8) ) );
 
-    temp = read_register(PQH_OFFSET, 4);
-    write_register(PQH_OFFSET, 4, temp + 1);
-    fail_if( ( temp != read_register(PQH_OFFSET, 4) ) );
+    temp = read_register(&iommu, PQH_OFFSET, 4);
+    write_register(&iommu, PQH_OFFSET, 4, temp + 1);
+    fail_if( ( temp != read_register(&iommu, PQH_OFFSET, 4) ) );
 
-    temp = read_register(PQT_OFFSET, 4);
-    write_register(PQT_OFFSET, 4, temp + 1);
-    fail_if( ( temp != read_register(PQT_OFFSET, 4) ) );
+    temp = read_register(&iommu, PQT_OFFSET, 4);
+    write_register(&iommu, PQT_OFFSET, 4, temp + 1);
+    fail_if( ( temp != read_register(&iommu, PQT_OFFSET, 4) ) );
 
-    write_register(ICVEC_OFFSET, 8, 0x0000000000005555);
-    fail_if( ( read_register(ICVEC_OFFSET, 8) != 0x0000000000000055) );
-    g_reg_file.capabilities.hpm = 1;
-    write_register(ICVEC_OFFSET, 8, 0x0000000000005555);
-    fail_if( ( read_register(ICVEC_OFFSET, 8) != 0x0000000000000555) );
-    g_reg_file.capabilities.ats = 1;
-    write_register(ICVEC_OFFSET, 8, 0x0000000000005555);
-    fail_if( ( read_register(ICVEC_OFFSET, 8) != 0x0000000000005555) );
+    write_register(&iommu, ICVEC_OFFSET, 8, 0x0000000000005555);
+    fail_if( ( read_register(&iommu, ICVEC_OFFSET, 8) != 0x0000000000000055) );
+    iommu.reg_file.capabilities.hpm = 1;
+    write_register(&iommu, ICVEC_OFFSET, 8, 0x0000000000005555);
+    fail_if( ( read_register(&iommu, ICVEC_OFFSET, 8) != 0x0000000000000555) );
+    iommu.reg_file.capabilities.ats = 1;
+    write_register(&iommu, ICVEC_OFFSET, 8, 0x0000000000005555);
+    fail_if( ( read_register(&iommu, ICVEC_OFFSET, 8) != 0x0000000000005555) );
     // test iommu_qosid
-    g_reg_file.capabilities.qosid = 1;
-    g_iommu_qosid_mask.raw = 0x00FF00FF;
-    write_register(IOMMU_QOSID_OFFSET, 4, 0x01230456);
-    fail_if( ( read_register(IOMMU_QOSID_OFFSET, 4) != 0x00230056) );
-    g_reg_file.capabilities.qosid = 0;
+    iommu.reg_file.capabilities.qosid = 1;
+    iommu.iommu_qosid_mask.raw = 0x00FF00FF;
+    write_register(&iommu, IOMMU_QOSID_OFFSET, 4, 0x01230456);
+    fail_if( ( read_register(&iommu, IOMMU_QOSID_OFFSET, 4) != 0x00230056) );
+    iommu.reg_file.capabilities.qosid = 0;
 
     END_TEST();
     return 0;

--- a/iommu_ref_model/test/test_app.h
+++ b/iommu_ref_model/test/test_app.h
@@ -5,27 +5,27 @@
 
 // Global functions
 extern int8_t reset_system(uint8_t mem_gb, uint16_t num_vms);
-extern int8_t enable_cq(uint32_t nppn);
-extern int8_t enable_fq(uint32_t nppn);
-extern int8_t enable_disable_pq(uint32_t nppn, uint8_t enable_disable);
-extern int8_t enable_iommu(uint8_t iommu_mode);
-extern void iodir(uint8_t f3, uint8_t DV, uint32_t DID, uint32_t PID);
-extern void iotinval( uint8_t f3, uint8_t GV, uint8_t AV, uint8_t PSCV, uint32_t GSCID, uint32_t PSCID, uint64_t address);
-extern void iofence(uint8_t f3, uint8_t PR, uint8_t PW, uint8_t AV, uint8_t WSI_bit, uint64_t addr, uint32_t data);
-extern void ats_command( uint8_t f3, uint8_t DSV, uint8_t PV, uint32_t PID, uint8_t DSEG, uint16_t RID, uint64_t payload);
-extern void generic_any(command_t cmd);
-extern void send_translation_request(uint32_t did, uint8_t pid_valid, uint32_t pid, uint8_t no_write,
+extern int8_t enable_cq(iommu_t *iommu, uint32_t nppn);
+extern int8_t enable_fq(iommu_t *iommu, uint32_t nppn);
+extern int8_t enable_disable_pq(iommu_t *iommu, uint32_t nppn, uint8_t enable_disable);
+extern int8_t enable_iommu(iommu_t *iommu, uint8_t iommu_mode);
+extern void iodir(iommu_t *iommu, uint8_t f3, uint8_t DV, uint32_t DID, uint32_t PID);
+extern void iotinval(iommu_t *iommu, uint8_t f3, uint8_t GV, uint8_t AV, uint8_t PSCV, uint32_t GSCID, uint32_t PSCID, uint64_t address);
+extern void iofence(iommu_t *iommu, uint8_t f3, uint8_t PR, uint8_t PW, uint8_t AV, uint8_t WSI_bit, uint64_t addr, uint32_t data);
+extern void ats_command(iommu_t *iommu, uint8_t f3, uint8_t DSV, uint8_t PV, uint32_t PID, uint8_t DSEG, uint16_t RID, uint64_t payload);
+extern void generic_any(iommu_t *iommu, command_t cmd);
+extern void send_translation_request(iommu_t *iommu, uint32_t did, uint8_t pid_valid, uint32_t pid, uint8_t no_write,
              uint8_t exec_req, uint8_t priv_req, uint8_t is_cxl_dev, addr_type_t at, uint64_t iova,
              uint32_t length, uint8_t read_writeAMO,
              hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp);
-extern int8_t check_rsp_and_faults(hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp, status_t status,
+extern int8_t check_rsp_and_faults(iommu_t *iommu, hb_to_iommu_req_t *req, iommu_to_hb_rsp_t *rsp, status_t status,
              uint16_t cause, uint64_t exp_iotval2);
-extern int8_t check_faults(uint16_t cause, uint8_t  exp_PV, uint32_t exp_PID,
+extern int8_t check_faults(iommu_t *iommu, uint16_t cause, uint8_t  exp_PV, uint32_t exp_PID,
              uint8_t  exp_PRIV, uint32_t exp_DID, uint64_t exp_iotval, uint8_t ttyp, uint64_t exp_iotval2);
-extern int8_t check_exp_pq_rec(uint32_t DID, uint32_t PID, uint8_t PV, uint8_t PRIV, uint8_t EXEC,
+extern int8_t check_exp_pq_rec(iommu_t *iommu, uint32_t DID, uint32_t PID, uint8_t PV, uint8_t PRIV, uint8_t EXEC,
              uint16_t reserved0, uint8_t reserved1, uint64_t PAYLOAD);
 extern uint64_t get_free_gppn(uint64_t num_gppn, iohgatp_t iohgatp);
-extern uint64_t add_device(uint32_t device_id, uint32_t gscid, uint8_t en_ats, uint8_t en_pri, uint8_t t2gpa,
+extern uint64_t add_device(iommu_t *iommu, uint32_t device_id, uint32_t gscid, uint8_t en_ats, uint8_t en_pri, uint8_t t2gpa,
            uint8_t dtf, uint8_t prpr,
            uint8_t gade, uint8_t sade, uint8_t dpe, uint8_t sbe, uint8_t sxl,
            uint8_t iohgatp_mode, uint8_t iosatp_mode, uint8_t pdt_mode,


### PR DESCRIPTION
Instead of using global variables to hold the state of the IOMMU, all of
the state has been added to a new struct called `iommu_t` which is defined in
`iommu_registers.h`.

This change makes it slightly more tedious to use the API because almost
all functions now take an extra parameter which is a pointer to the 
relevant `iommu_t` instance, but it has the benefit that you can 
instantiate multiple `iommu_t`'s, thus making it possible to model systems
which have multiple IOMMUs.

It also makes it easier to save/restore the state of the IOMMU and makes
it easier to find the variables which constitute the state of the IOMMU.