### PR TITLE
Make ATS commands illegal when capabilities.ATS is 0

### DIFF
--- a/iommu_ref_model/libiommu/src/iommu_command_queue.c
+++ b/iommu_ref_model/libiommu/src/iommu_command_queue.c
@@ -182,6 +182,7 @@ process_commands(
             }
             break;
         case ATS:
+            if ( iommu->reg_file.capabilities.ats == 0 ) goto command_illegal;
             if ( command.ats.rsvd != 0 || command.ats.rsvd1 != 0 ) goto command_illegal;
             switch ( command.any.func3 ) {
                 case INVAL:

--- a/iommu_ref_model/test/test_app.c
+++ b/iommu_ref_model/test/test_app.c
@@ -3939,6 +3939,34 @@ main(void) {
     cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
     fail_if( ( cqcsr.cmd_ill != 0 ) );
 
+    // ATS commands only supported when capabilities.ATS is 1
+
+    iommu.reg_file.capabilities.ats = 0;
+
+    ats_command(&iommu, INVAL, 1, 1, 0xbabec, 0x43, 0x1234, 0xdeadbeeffeedbeef);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
+    fail_if( ( cqcsr.cmd_ill != 1 ) );
+
+    // clear cmd_ill
+    cqcsr.cqen = 0;
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
+    cqcsr.cqen = 1;
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+
+    ats_command(&iommu, PRGR, 1, 0, 0xbabec, 0x43, 0x1234, 0xdeadbeeffeedbeef);
+    cqcsr.raw = read_register(&iommu, CQCSR_OFFSET, 4);
+    fail_if( ( cqcsr.cmd_ill != 1 ) );
+
+    // clear cmd_ill
+    cqcsr.cqen = 0;
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+    write_register(&iommu, CQT_OFFSET, 4, 0);
+    cqcsr.cqen = 1;
+    write_register(&iommu, CQCSR_OFFSET, 4, cqcsr.raw);
+
+    iommu.reg_file.capabilities.ats = 1;
+
     // idle
     process_commands(&iommu);
 


### PR DESCRIPTION
See 4.1.4 in IOMMU spec