### PR TITLE
Fix GET_PC PDT walk index from PDI[2] to PDI[i]

### DIFF
--- a/src/iommu_data_structures.adoc
+++ b/src/iommu_data_structures.adoc
@@ -1129,7 +1129,7 @@ The process to locate the Process-context for a transaction using its
 . Let `a` be `pdtp.PPN x 2^12^` and let `i = LEVELS - 1`. When
   `pdtp.MODE` is `PD20`, `LEVELS` is three. When `pdtp.MODE` is
   `PD17`, `LEVELS` is two. When `pdtp.MODE` is `PD8`, `LEVELS` is one.
-. If `i != 0`, then let `a = a + PDI[2] × 8`; otherwise, let
+. If `i != 0`, then let `a = a + PDI[i] × 8`; otherwise, let
   `a = a + PDI[0] × 16`.
 . If `DC.iohgatp.mode != Bare`, then `a` is a GPA. Invoke the process
   to translate `a` to a SPA as an implicit memory access. If faults occur during


### PR DESCRIPTION

Fix GET_PC step 2 to use the current PDT walk level index `PDI[i]` instead of the hardcoded `PDI[2]`.

The hardcoded form is incorrect for non-leaf level `i=1` in PD17/PD20 walks. This aligns the process-context walk with the analogous device-context walk, which uses `DDI[i]`.